### PR TITLE
TH flag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 *.ps
 *.swp
 cabal-dev
+.DS_Store

--- a/distributed-process/distributed-process.cabal
+++ b/distributed-process/distributed-process.cabal
@@ -29,6 +29,10 @@ Source-Repository head
   Location: https://github.com/haskell-distributed/distributed-process
   SubDir:   distributed-process
 
+flag th
+  description: Build with Template Haskell support
+  default: True
+
 Library
   Build-Depends:     base >= 4.4 && < 5,
                      binary >= 0.5 && < 0.6,
@@ -41,7 +45,6 @@ Library
                      containers >= 0.4 && < 0.6,
                      old-locale >= 1.0 && < 1.1,
                      time >= 1.2 && < 1.5,
-                     template-haskell >= 2.6 && < 2.9,
                      random >= 1.0 && < 1.1,
                      ghc-prim >= 0.2 && < 0.4,
                      distributed-static >= 0.1 && < 0.2,
@@ -54,7 +57,6 @@ Library
                      Control.Distributed.Process.Internal.Primitives,
                      Control.Distributed.Process.Internal.CQueue,
                      Control.Distributed.Process.Internal.Types,
-                     Control.Distributed.Process.Internal.Closure.TH,
                      Control.Distributed.Process.Internal.Closure.BuiltIn,
                      Control.Distributed.Process.Internal.Node
   Extensions:        RankNTypes,
@@ -68,6 +70,9 @@ Library
                      CPP
   ghc-options:       -Wall
   HS-Source-Dirs:    src
+  if flag(th)
+     Build-Depends: template-haskell >= 2.6 && < 2.9
+     Exposed-modules: Control.Distributed.Process.Internal.Closure.TH
 
 Test-Suite TestCH
   Type:              exitcode-stdio-1.0

--- a/distributed-process/src/Control/Distributed/Process/Closure.hs
+++ b/distributed-process/src/Control/Distributed/Process/Closure.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | /Towards Haskell in the Cloud/ (Epstein et al., Haskell Symposium 2011)
 -- proposes a new type construct called 'static' that characterizes values that
 -- are known statically. Cloud Haskell uses the
@@ -156,14 +157,8 @@
 --      instance into scope, but unless proper 'static' support is added to
 --      ghc we need both the type class argument and the explicit dictionary. 
 module Control.Distributed.Process.Closure 
-  ( -- * Template Haskell support for creating static values and closures 
-    remotable
-  , mkStatic
-  , mkClosure
-  , functionSDict
-  , functionTDict
-    -- * Serialization dictionaries (and their static versions)
-  , SerializableDict(..)
+  ( -- * Serialization dictionaries (and their static versions)
+    SerializableDict(..)
   , staticDecode
   , sdictUnit
   , sdictProcessId
@@ -181,16 +176,17 @@ module Control.Distributed.Process.Closure
   , cpSend
   , cpExpect
   , cpNewChan
+    -- * Template Haskell support for creating static values and closures 
+#ifdef TH
+  , remotable
+  , mkStatic
+  , mkClosure
+  , functionSDict
+  , functionTDict
+#endif
   ) where 
 
 import Control.Distributed.Process.Serializable (SerializableDict(..))
-import Control.Distributed.Process.Internal.Closure.TH 
-  ( remotable
-  , mkStatic
-  , functionSDict
-  , functionTDict
-  , mkClosure
-  )
 import Control.Distributed.Process.Internal.Closure.BuiltIn
   ( -- Static dictionaries and associated operations
     staticDecode
@@ -211,3 +207,12 @@ import Control.Distributed.Process.Internal.Closure.BuiltIn
   , cpExpect
   , cpNewChan
   )
+#ifdef TH
+import Control.Distributed.Process.Internal.Closure.TH 
+  ( remotable
+  , mkStatic
+  , functionSDict
+  , functionTDict
+  , mkClosure
+  )
+#endif


### PR DESCRIPTION
Added the TH flag (default: True), enabling the build for architectures that don't have support for TH.

Enhanced the ignore file.

Reordered the exports/imports in C.D.P.Closure module.
