### PR TITLE
Re-export MonitorRef in the Process module

### DIFF
--- a/distributed-process/src/Control/Distributed/Process.hs
+++ b/distributed-process/src/Control/Distributed/Process.hs
@@ -62,6 +62,7 @@ module Control.Distributed.Process
   , monitorNode
   , monitorPort
   , unmonitor
+  , MonitorRef
   , ProcessLinkException(..)
   , NodeLinkException(..)
   , PortLinkException(..)


### PR DESCRIPTION
I am not sure if this is as designed, but the Process module doesn't export MonitorRef , only monitor. Right now I have to import Process(monitor) and Types(MonitorRef). Wouldnt it be cleaner to re-export MonitorRef in the Module so keep the internal modules hidden?
