### PR TITLE
Successfully build on ghc-7.6.1

### DIFF
--- a/network-transport-inmemory/network-transport-inmemory.cabal
+++ b/network-transport-inmemory/network-transport-inmemory.cabal
@@ -19,8 +19,8 @@ Library
   Build-Depends:   base >= 4.3 && < 5,
                    network-transport >= 0.3 && < 0.4,
                    data-accessor >= 0.2 && < 0.3,
-                   bytestring >= 0.9 && < 0.10,
-                   containers >= 0.4 && < 0.5
+                   bytestring >= 0.9 && < 0.11,
+                   containers >= 0.4 && < 0.6
   Exposed-modules: Network.Transport.Chan
   ghc-options:     -Wall -fno-warn-unused-do-bind
   HS-Source-Dirs:  src


### PR DESCRIPTION
just increased the dependency for bytestring and containers in network-transport-inmemory so that those dependencies don't conflict with those used by ghc-7.6.1
