### PR TITLE
support current versions of test-platfrom-*

### DIFF
--- a/distributed-process/distributed-process.cabal
+++ b/distributed-process/distributed-process.cabal
@@ -96,8 +96,8 @@ Test-Suite TestCH
                      binary >= 0.5 && < 0.7,
                      network >= 2.3 && < 2.5,
                      HUnit >= 1.2 && < 1.3,
-                     test-framework >= 0.6 && < 0.7,
-                     test-framework-hunit >= 0.2 && < 0.3
+                     test-framework == 0.6.* || == 0.8.*,
+                     test-framework-hunit == 0.2.* && == 0.4.*
   Extensions:        CPP,
                      ScopedTypeVariables,
                      DeriveDataTypeable,
@@ -118,9 +118,9 @@ Test-Suite TestClosure
                      bytestring >= 0.9 && < 0.11,
                      network >= 2.3 && < 2.5,
                      HUnit >= 1.2 && < 1.3,
-                     test-framework >= 0.6 && < 0.7,
-                     test-framework-hunit >= 0.2 && < 0.3
-  Extensions:        CPP, 
+                     test-framework == 0.6.* || == 0.8.*,
+                     test-framework-hunit == 0.2.* || == 0.4.*
+  Extensions:        CPP,
                      ScopedTypeVariables
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests


### PR DESCRIPTION
This patch changes the version constraints to for test-platform and test-platform-hunit to support the current versions of those packages. The system compiles and the tests run with those changes. 

The original version of this code explicitly excluded version versions 0.7 and 0.3 respectively. These changes continue explicitly excluding those versions. 

I think a better patch would be to move the constraints from a whitelist to a blacklist. That is, instead of listing known good versions in the constraints explicitly disqualify known-bad versions. 
