### PR TITLE
Expose Message and broaden the scope of polymorphic expect

### DIFF
--- a/src/Control/Distributed/Process.hs
+++ b/src/Control/Distributed/Process.hs
@@ -42,10 +42,16 @@ module Control.Distributed.Process
   , match
   , matchIf
   , matchUnknown
-  , AbstractMessage(..)
   , matchAny
   , matchAnyIf
   , matchChan
+  , Message
+  , matchMessage
+  , matchMessageIf
+  , wrapMessage
+  , unwrapMessage
+  , handleMessage
+  , forward
     -- * Process management
   , spawn
   , call
@@ -167,6 +173,7 @@ import Control.Distributed.Process.Internal.Types
   , WhereIsReply(..)
   , RegisterReply(..)
   , LocalProcess(processNode)
+  , Message
   , nullProcessId
   )
 import Control.Distributed.Process.Serializable (Serializable, SerializableDict)
@@ -199,10 +206,15 @@ import Control.Distributed.Process.Internal.Primitives
   , match
   , matchIf
   , matchUnknown
-  , AbstractMessage(..)
   , matchAny
   , matchAnyIf
   , matchChan
+  , matchMessage
+  , matchMessageIf
+  , wrapMessage
+  , unwrapMessage
+  , handleMessage
+  , forward
     -- Process management
   , terminate
   , ProcessTerminationException(..)

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -307,6 +307,7 @@ data Message = Message
   { messageFingerprint :: !Fingerprint
   , messageEncoding    :: !BSL.ByteString
   }
+  deriving (Typeable)
 
 instance Show Message where
   show (Message fp enc) = show enc ++ " :: " ++ showFingerprint fp []
@@ -488,6 +489,10 @@ data ProcessSignal =
 --------------------------------------------------------------------------------
 -- Binary instances                                                           --
 --------------------------------------------------------------------------------
+
+instance Binary Message where
+  put msg = put $ messageToPayload msg
+  get = payloadToMessage <$> get
 
 instance Binary LocalProcessId where
   put lpid = put (lpidUnique lpid) >> put (lpidCounter lpid)


### PR DESCRIPTION
Remove AbstractMessage and replace its forward and maybeHandleMessage
API with versions that operate directly on Message. Create Typeable
and Binary instances for Message and export the type from Process.hs
(though not the constructor). Provide functions for matching, wrapping
and unwrapping Message.

Fixes issue #30.
