### PR TITLE
Fixes mask so unmask uses the correct state.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -623,10 +623,11 @@ mask :: ((forall a. Process a -> Process a) -> Process b) -> Process b
 mask p = do
     lproc <- ask
     liftIO $ Ex.mask $ \restore ->
-      runLocalProcess lproc (p (liftRestore lproc restore))
+      runLocalProcess lproc (p $ liftRestore restore)
   where
-    liftRestore :: LocalProcess -> (forall a. IO a -> IO a) -> (forall a. Process a -> Process a)
-    liftRestore lproc restoreIO = liftIO . restoreIO . runLocalProcess lproc
+    liftRestore :: (forall a. IO a -> IO a) -> (forall a. Process a -> Process a)
+    liftRestore restoreIO p' = do lproc <- ask
+                                  liftIO $ restoreIO $ runLocalProcess lproc p'
 
 -- | Lift 'Control.Exception.onException'
 onException :: Process a -> Process b -> Process a


### PR DESCRIPTION
Otherwise the following program would yield False.

```
import Control.Distributed.Process
import Control.Distributed.Process.Node
import Control.Monad ( void )
import Network.Transport.TCP

main :: IO ()
main = do
  Right transport <- createTransport "127.0.0.1" "8080"
  defaultTCPParameters
  lnid <- newLocalNode transport initRemoteTable
  runProcess lnid $ do
    pid <- getSelfPid
    void $ mask $ \unmask -> do
      spawnLocal $ void $ unmask getSelfPid >>= send pid
      expect >>= liftIO . print . (pid/=)
```
