### PR TITLE
Fix mask when used in conjunction with spawn

### DIFF
--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -623,10 +623,12 @@ mask :: ((forall a. Process a -> Process a) -> Process b) -> Process b
 mask p = do
     lproc <- ask
     liftIO $ Ex.mask $ \restore ->
-      runLocalProcess lproc (p (liftRestore lproc restore))
+      runLocalProcess lproc (p (liftRestore restore))
   where
-    liftRestore :: LocalProcess -> (forall a. IO a -> IO a) -> (forall a. Process a -> Process a)
-    liftRestore lproc restoreIO = liftIO . restoreIO . runLocalProcess lproc
+    liftRestore :: (forall a. IO a -> IO a) -> (forall a. Process a -> Process a)
+    liftRestore restoreIO = \p2 -> do
+      llproc <- ask
+      liftIO $ restoreIO $ runLocalProcess llproc p2
 
 -- | Lift 'Control.Exception.onException'
 onException :: Process a -> Process b -> Process a


### PR DESCRIPTION
C.D.P.Internal.Primtives.mask does not work correctly if unmask is
called by a process other than the one that called mask. An example
of this behavior is in callLocal below. The expected behavior of test is this:

Wed May  8 22:50:01 UTC 2013 pid://127.0.0.1:8080:0:3: hi
Wed May  8 22:50:01 UTC 2013 pid://127.0.0.1:8080:0:4: hi
Wed May  8 22:50:01 UTC 2013 pid://127.0.0.1:8080:0:5: hi

Each say is emitted by a distinct process. However, the observed
behavior is given here:

Wed May  8 22:38:57 UTC 2013 pid://127.0.0.1:8080:0:3: hi
Wed May  8 22:38:57 UTC 2013 pid://127.0.0.1:8080:0:4: hi
Wed May  8 22:38:57 UTC 2013 pid://127.0.0.1:8080:0:3: hi

Note that the say called within callLocal thinks it is running
in the same process as its parent, even though there is a
spawnLocal between them.

This commit fixes this behavior.

> callLocal :: Process a -> Process a
> callLocal p = do
>   mv <- liftIO $ newEmptyMVar
>   mask $ \unmask -> do
>     spawnLocal $ unmask p >>= liftIO . putMVar mv
>   liftIO $ takeMVar mv
> 
> test :: Process ()
> test =
>   do say "hi"
>      spawnLocal $ say "hi"
>      callLocal $ say "hi"
>      return ()
