### PR TITLE
need binary >= 0.7.0 for Generic deriving

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -43,7 +43,7 @@ flag prof
 
 Library
   Build-Depends:     base >= 4.4 && < 5,
-                     binary >= 0.5 && < 0.8,
+                     binary >= 0.7 && < 0.8,
                      deepseq >= 1.3.0.1 && < 1.4,
                      hashable >= 1.2.0.5 && < 1.3,
                      network-transport >= 0.3 && < 0.4,


### PR DESCRIPTION
I got tricked this evening.
