### PR TITLE
Add readMVar

### DIFF
--- a/src/Control/Distributed/Process/Internal/StrictMVar.hs
+++ b/src/Control/Distributed/Process/Internal/StrictMVar.hs
@@ -6,6 +6,7 @@ module Control.Distributed.Process.Internal.StrictMVar
   , newMVar
   , takeMVar
   , putMVar
+  , readMVar
   , withMVar
   , modifyMVar_
   , modifyMVar
@@ -21,6 +22,7 @@ import qualified Control.Concurrent.MVar as MVar
   , newMVar
   , takeMVar
   , putMVar
+  , readMVar
   , withMVar
   , modifyMVar_
   , modifyMVar
@@ -43,6 +45,9 @@ takeMVar (StrictMVar v) = MVar.takeMVar v
 
 putMVar :: StrictMVar a -> a -> IO ()
 putMVar (StrictMVar v) x = evaluate x >> MVar.putMVar v x
+
+readMVar :: StrictMVar a -> IO a
+readMVar (StrictMVar v) = MVar.readMVar v
 
 withMVar :: StrictMVar a -> (a -> IO b) -> IO b
 withMVar (StrictMVar v) = MVar.withMVar v


### PR DESCRIPTION
This change seems to be missing in the last commit to the development branch, since it currently doesn't compile.
https://github.com/haskell-distributed/distributed-process/commit/ea1b3b8542aeae0ff6d19926a8b8803d5fc688a8
