### PR TITLE
Have d-p-test build with ghc-7.4.2.

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -44,7 +44,6 @@ flag prof
 Library
   Build-Depends:     base >= 4.4 && < 5,
                      binary >= 0.5 && < 0.8,
-                     deepseq >= 1.3.0.1 && < 1.4,
                      hashable >= 1.2.0.5 && < 1.3,
                      network-transport >= 0.3 && < 0.4,
                      stm >= 2.4 && < 2.5,
@@ -52,7 +51,6 @@ Library
                      mtl >= 2.0 && < 2.2,
                      data-accessor >= 0.2 && < 0.3,
                      bytestring >= 0.9 && < 0.11,
-                     containers >= 0.4 && < 0.6,
                      old-locale >= 1.0 && < 1.1,
                      time >= 1.2 && < 1.5,
                      random >= 1.0 && < 1.1,
@@ -99,8 +97,17 @@ Library
                      BangPatterns
   ghc-options:       -Wall
   HS-Source-Dirs:    src
+  if impl(ghc <= 7.4.2)
+     Build-Depends:   containers >= 0.4 && < 0.5,
+                      deepseq == 1.3.0.0
+  else
+     Build-Depends:   containers >= 0.4 && < 0.6,
+                      deepseq >= 1.3.0.1 && < 1.4
   if flag(th)
-     Build-Depends:   template-haskell >= 2.6 && < 2.9
+     if impl(ghc <= 7.4.2)
+       Build-Depends: template-haskell >= 2.7 && < 2.8
+     else
+       Build-Depends: template-haskell >= 2.6 && < 2.9
      Exposed-modules: Control.Distributed.Process.Internal.Closure.TH
      CPP-Options:     -DTemplateHaskellSupport
 


### PR DESCRIPTION
Because d-p depended on deepseq >= 1.3.0.1 and ghc-7.4.2 ships deepseq-1.3.0.0, cabal would install a newer deepseq. Then in turn, cabal would rebuild reverse dependencies of deepseq which included the template-haskell package, which would cause the compiler to crash when compiling tests using template haskell.

The lower bound of deepseq was moved to 1.3.0.0. But then d-p would fail to build because
src/Control/Distributed/Process/Management/Table.hs
uses Data.Map.Strict wich is not available in containers-0.4.2.1 shipped with ghc-7.4.2, and it is also a dependency of template-haskell.

The solution was to use Data.Map instead, and insert seqs in Table.hs to achieve the semantics expected of Data.Map.Strict.

Finally, for ghc-7.4.2 the version bounds are tightened so it is easier for cabal to find conflicts related to template-haskell.
