### PR TITLE
switch to explicit per-file LANGUAGE pragmas instead of defaults

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -87,16 +87,7 @@ Library
                      Control.Distributed.Process.Management.Trace.Remote,
                      Control.Distributed.Process.Management.Trace.Types,
                      Control.Distributed.Process.Management.Trace.Tracer
-  Extensions:        RankNTypes,
-                     ScopedTypeVariables,
-                     FlexibleInstances,
-                     UndecidableInstances,
-                     ExistentialQuantification,
-                     GADTs,
-                     GeneralizedNewtypeDeriving,
-                     DeriveDataTypeable,
-                     CPP,
-                     BangPatterns
+  -- Extensions:     -- we use explicit per-file LANGUAGE pragmas
   ghc-options:       -Wall
   HS-Source-Dirs:    src
   if flag(th)

--- a/src/Control/Distributed/Process.hs
+++ b/src/Control/Distributed/Process.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP  #-}
 {- | [Cloud Haskell]
 
 This is an implementation of Cloud Haskell, as described in

--- a/src/Control/Distributed/Process/Debug.hs
+++ b/src/Control/Distributed/Process/Debug.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE CPP  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes  #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Distributed.Process.Debug
@@ -274,4 +277,3 @@ stopTracer =
     case basePid == (Just pid) of
       True  -> return ()
       False -> send pid MxTraceDisable
-

--- a/src/Control/Distributed/Process/Internal/CQueue.hs
+++ b/src/Control/Distributed/Process/Internal/CQueue.hs
@@ -1,5 +1,6 @@
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards, ScopedTypeVariables, RankNTypes #-}
 -- | Concurrent queue for single reader, single writer
-{-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards #-}
 module Control.Distributed.Process.Internal.CQueue
   ( CQueue
   , BlockSpec(..)

--- a/src/Control/Distributed/Process/Internal/Closure/BuiltIn.hs
+++ b/src/Control/Distributed/Process/Internal/Closure/BuiltIn.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes  #-}
 module Control.Distributed.Process.Internal.Closure.BuiltIn
   ( -- * Remote table
     remoteTable
@@ -296,6 +298,3 @@ cpDelay = closureApply . cpDelay'
 
     delayStatic :: Static (ProcessId -> Process () -> Process ())
     delayStatic = staticLabel "$delay"
-
-
-

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP  #-}
+{-# LANGUAGE RankNTypes  #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE BangPatterns #-}
 
 -- | Cloud Haskell primitives

--- a/src/Control/Distributed/Process/Internal/Spawn.hs
+++ b/src/Control/Distributed/Process/Internal/Spawn.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes  #-}
 module Control.Distributed.Process.Internal.Spawn
   ( spawn
   , spawnLink
@@ -158,4 +159,3 @@ spawnChannel dict nid proc = do
              (cpSend (sdictSendPort dict) pid `splitCP` proc)
            `bindCP`
              (idCP `closureCompose` staticClosure sndStatic)
-

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
+{-# LANGUAGE GADTs  #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 -- | Types used throughout the Cloud Haskell framework

--- a/src/Control/Distributed/Process/Internal/WeakTQueue.hs
+++ b/src/Control/Distributed/Process/Internal/WeakTQueue.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
 -- | Clone of Control.Concurrent.STM.TQueue with support for mkWeakTQueue
 --
 -- Not all functionality from the original module is available: unGetTQueue,
 -- peekTQueue and tryPeekTQueue are missing. In order to implement these we'd
 -- need to be able to touch# the write end of the queue inside unGetTQueue, but
 -- that means we need a version of touch# that works within the STM monad.
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
 module Control.Distributed.Process.Internal.WeakTQueue (
   -- * Original functionality
   TQueue,

--- a/src/Control/Distributed/Process/Management/Agent.hs
+++ b/src/Control/Distributed/Process/Management/Agent.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Control.Distributed.Process.Management.Agent where
@@ -153,4 +154,3 @@ startDeadLetterQueue sigbus = do
   chan' <- atomically (dupTChan sigbus)
   void $ forkIO $ forever' $ do
     void $ atomically $ readTChan chan'
-

--- a/src/Control/Distributed/Process/Management/Table.hs
+++ b/src/Control/Distributed/Process/Management/Table.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes  #-}
 {-# LANGUAGE DeriveGeneric   #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -217,4 +220,3 @@ getEntry k m MxTableState{..} = do
 
 entries :: Accessor MxTableState (Map String Message)
 entries = accessor _entries (\ls st -> st { _entries = ls })
-

--- a/src/Control/Distributed/Process/Management/Trace/Primitives.hs
+++ b/src/Control/Distributed/Process/Management/Trace/Primitives.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 -- | Keeps the tracing API calls separate from the Tracer implementation,
 -- which allows us to avoid a nasty import cycle between tracing and
 -- the messaging primitives that rely on it, and also between the node

--- a/src/Control/Distributed/Process/Management/Trace/Tracer.hs
+++ b/src/Control/Distributed/Process/Management/Trace/Tracer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 -- | Tracing/Debugging support - Trace Implementation
 module Control.Distributed.Process.Management.Trace.Tracer
   ( -- * API for the Management Agent
@@ -343,4 +345,3 @@ sendTrace st ev msg = do
 sendTraceMsg :: Maybe ProcessId -> Message -> Process ()
 sendTraceMsg Nothing  _   = return ()
 sendTraceMsg (Just p) msg = (flip forward) p msg
-

--- a/src/Control/Distributed/Process/Management/Trace/Types.hs
+++ b/src/Control/Distributed/Process/Management/Trace/Types.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE GADTs  #-}
 {-# LANGUAGE DeriveGeneric  #-}
 
 -- | Tracing/Debugging support - Types
@@ -162,4 +167,3 @@ instance Traceable ProcessId where
 
 instance Traceable String where
   uod = TraceNames . Set.fromList
-

--- a/src/Control/Distributed/Process/Management/Types.hs
+++ b/src/Control/Distributed/Process/Management/Types.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE DeriveGeneric   #-}
 module Control.Distributed.Process.Management.Types
   ( MxAgentId(..)
@@ -145,4 +149,3 @@ data MxAction =
 
 -- | Type of a management agent's event sink.
 type MxSink s = Message -> MxAgent s (Maybe MxAction)
-

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE CPP  #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes  #-}
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Local nodes

--- a/src/Control/Distributed/Process/Serializable.hs
+++ b/src/Control/Distributed/Process/Serializable.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs  #-}
 module Control.Distributed.Process.Serializable
   ( Serializable
   , encodeFingerprint


### PR DESCRIPTION
This makes it much easier to traverse the code in ghci from other projects using d-p.
Also remove Extensions field in .cabal. See discussion on PR #146.
