### PR TITLE
fix cabal documentation geneneration

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -17,7 +17,7 @@ Description:   This is an implementation of Cloud Haskell, as described in
                (<http://research.microsoft.com/en-us/um/people/simonpj/papers/parallel/>),
                although some of the details are different. The precise message
                passing semantics are based on /A unified semantics for future Erlang/
-               by Hans Svensson, Lars-Åke Fredlund and Clara Benac Earle.
+               by Hans Svensson, Lars-&#xc5;ke Fredlund and Clara Benac Earle.
 
                You will probably also want to install a Cloud Haskell backend such
                as distributed-process-simplelocalnet.


### PR DESCRIPTION
generation of cabal documentation fails due to unicode character in cabal file. Replaced it with its html entity version fixes build.

Documentation on haddock ist also broken at the moment. Should be fixed with this.
https://hackage.haskell.org/package/distributed-process
