### PR TITLE
Remove Travis 'notifications:' section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,3 @@ install:
 
 script:
   - ./travis/scripts/script.sh
-
-notifications:
-  email:
-    recipients:
-      - cloud.haskell@gmail.com
-  irc:
-    channels:
-      - "irc.freenode.org#haskell-distributed"
-    use_notice: true
-    template:
-      - "\x0313distributed-process\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
-


### PR DESCRIPTION
It had three problems:
- it always notifies the Cloud Haskell maintainer email address (and
  the #haskell-distributed IRC channel), even for pushes done in
  a fork (public or private) that the Cloud Haskell maintainer has no
  control over.
- it inhibited notifying the actual committers and authors the way the
  default does.
