### PR TITLE
Make forkProcess exception-safe.

### DIFF
--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -64,9 +64,10 @@ import Control.Exception
   , SomeException
   , Exception
   , throwTo
+  , uninterruptibleMask_
   )
 import qualified Control.Exception as Exception (Handler(..), catches, finally)
-import Control.Concurrent (forkIO, myThreadId)
+import Control.Concurrent (forkIO, forkIOWithUnmask, myThreadId)
 import Control.Distributed.Process.Internal.StrictMVar
   ( newMVar
   , withMVar
@@ -357,9 +358,9 @@ forkProcess node proc = modifyMVar (localState node) startProcess
                                  , processThread = tid
                                  , processNode   = node
                                  }
-        tid' <- forkIO $ do
+        tid' <- uninterruptibleMask_ $ forkIOWithUnmask $ \unmask -> do
           reason <- Exception.catches
-            (runLocalProcess lproc proc >> return DiedNormal)
+            (unmask $ runLocalProcess lproc proc >> return DiedNormal)
             [ (Exception.Handler (\ex@(ProcessExitException from msg) -> do
                  mMsg <- unwrapMessage msg :: IO (Maybe String)
                  case mMsg of


### PR DESCRIPTION
Before this patch, killing a process while it was terminating could
leave the `LocalNode` in an inconsistent state if an async exception is
thrown.

Bug originally spotted by Facundo Domínguez.
