### PR TITLE
MonadControl instance for Process.

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -54,7 +54,9 @@ Library
                      ghc-prim >= 0.2 && < 0.4,
                      distributed-static >= 0.2 && < 0.4,
                      rank1dynamic >= 0.1 && < 0.3,
-                     syb >= 0.3 && < 0.5
+                     syb >= 0.3 && < 0.5,
+                     transformers-base >= 0.3 && < 0.5,
+                     monad-control >= 0.3 && < 0.4
   Exposed-modules:   Control.Distributed.Process,
                      Control.Distributed.Process.Closure,
                      Control.Distributed.Process.Debug,

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE GADTs  #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Types used throughout the Cloud Haskell framework
 --
@@ -108,7 +110,9 @@ import Control.Concurrent.STM.TChan (TChan)
 import qualified Network.Transport as NT (EndPoint, EndPointAddress, Connection)
 import Control.Applicative (Applicative, Alternative, (<$>), (<*>))
 import Control.Monad.Reader (MonadReader(..), ReaderT, runReaderT)
-import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Base (MonadBase(..))
+import Control.Monad.Trans.Control (MonadBaseControl(..))
 import Control.Distributed.Process.Serializable
   ( Fingerprint
   , Serializable
@@ -290,7 +294,19 @@ data LocalProcessState = LocalProcessState
 newtype Process a = Process {
     unProcess :: ReaderT LocalProcess IO a
   }
-  deriving (Functor, Monad, MonadIO, MonadReader LocalProcess, Typeable, Applicative)
+  deriving (Applicative, Functor, Monad, MonadIO, MonadReader LocalProcess, Typeable)
+
+instance MonadBase IO Process where
+  liftBase = liftIO
+
+instance MonadBaseControl IO Process where
+  newtype StM Process a =
+    StMProcess { unStMProcess :: StM (ReaderT LocalProcess IO) a }
+
+  liftBaseWith f = Process $ liftBaseWith $ \run ->
+      f $ fmap StMProcess . run . unProcess
+
+  restoreM = Process . restoreM . unStMProcess
 
 --------------------------------------------------------------------------------
 -- Typed channels                                                             --


### PR DESCRIPTION
A `MonadControl` instance makes it possible to lift many actions with an
occurrence of `IO` in negative position to the `Process` monad. See e.g.
the async library, which contains many such actions. This patch makes it
possible to use `async` with `distributed-process`, via `lifted-async`.
