### PR TITLE
Fix docstring for `register`.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -1025,11 +1025,9 @@ say string = do
 -- Registry                                                                   --
 --------------------------------------------------------------------------------
 
--- | Register a process with the local registry (asynchronous).
--- This version will wait until a response is gotten from the
--- management process. The name must not already be registered.
--- The process need not be on this node.
--- A bad registration will result in a 'ProcessRegistrationException'
+-- | Register a process with the local registry (synchronous). The name must not
+--  already be registered. The process need not be on this node. A bad
+--  registration will result in a 'ProcessRegistrationException'
 --
 -- The process to be registered does not have to be local itself.
 register :: String -> ProcessId -> Process ()


### PR DESCRIPTION
It said "asynchronous", when clearly "synchronous" was meant. From the
moment that word is said, the second sentence becomes redundant, and
arguably exposes unnecessary implementation detail to the user.
