### PR TITLE
More informative ProcessRegistrationException.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -1044,9 +1044,10 @@ registerImpl :: Bool -> String -> ProcessId -> Process ()
 registerImpl force label pid = do
   mynid <- getSelfNode
   sendCtrlMsg Nothing (Register label mynid (Just pid) force)
-  receiveWait [ matchIf (\(RegisterReply label' _) -> label == label')
-                        (\(RegisterReply _ ok) -> handleRegistrationReply label ok)
-              ]
+  receiveWait
+    [ matchIf (\(RegisterReply label' _ _) -> label == label')
+              (\(RegisterReply _ ok owner) -> handleRegistrationReply label ok owner)
+    ]
 
 -- | Register a process with a remote registry (asynchronous).
 --
@@ -1069,16 +1070,17 @@ unregister :: String -> Process ()
 unregister label = do
   mynid <- getSelfNode
   sendCtrlMsg Nothing (Register label mynid Nothing False)
-  receiveWait [ matchIf (\(RegisterReply label' _) -> label == label')
-                        (\(RegisterReply _ ok) -> handleRegistrationReply label ok)
-              ]
+  receiveWait
+    [ matchIf (\(RegisterReply label' _ _) -> label == label')
+              (\(RegisterReply _ ok owner) -> handleRegistrationReply label ok owner)
+    ]
 
 -- | Deal with the result from an attempted registration or unregistration
 -- by throwing an exception if necessary
-handleRegistrationReply :: String -> Bool -> Process ()
-handleRegistrationReply label ok =
+handleRegistrationReply :: String -> Bool -> Maybe ProcessId -> Process ()
+handleRegistrationReply label ok owner =
   when (not ok) $
-     liftIO $ throwIO $ ProcessRegistrationException label
+     liftIO $ throwIO $ ProcessRegistrationException label owner
 
 -- | Remove a process from a remote registry (asynchronous).
 --

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -461,9 +461,11 @@ data PortLinkException =
 
 -- | Exception thrown when a process attempts to register
 -- a process under an already-registered name or to
--- unregister a name that hasn't been registered
+-- unregister a name that hasn't been registered. Returns
+-- the name and the identifier of the process that owns it,
+-- if any.
 data ProcessRegistrationException =
-    ProcessRegistrationException !String
+    ProcessRegistrationException !String !(Maybe ProcessId)
   deriving (Typeable, Show)
 
 -- | Internal exception thrown indirectly by 'exit'
@@ -524,7 +526,7 @@ data WhereIsReply = WhereIsReply String (Maybe ProcessId)
   deriving (Show, Typeable)
 
 -- | (Asynchronous) reply from 'register' and 'unregister'
-data RegisterReply = RegisterReply String Bool
+data RegisterReply = RegisterReply String Bool (Maybe ProcessId)
   deriving (Show, Typeable)
 
 data NodeStats = NodeStats {
@@ -693,8 +695,8 @@ instance Binary WhereIsReply where
   get = WhereIsReply <$> get <*> get
 
 instance Binary RegisterReply where
-  put (RegisterReply label ok) = put label >> put ok
-  get = RegisterReply <$> get <*> get
+  put (RegisterReply label ok owner) = put label >> put ok >> put owner
+  get = RegisterReply <$> get <*> get <*> get
 
 instance Binary ProcessInfo where
   get = ProcessInfo <$> get <*> get <*> get <*> get <*> get
@@ -761,4 +763,3 @@ typedChannelWithId cid = typedChannels >>> DAC.mapMaybe cid
 {-# INLINE forever' #-}
 forever' :: Monad m => m a -> m b
 forever' a = let a' = a >> a' in a'
-

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -841,17 +841,18 @@ ncEffectRegister from label atnode mPid reregistration = do
               return $ (isNothing currentVal /= reregistration) &&
                 (not (isLocal node (ProcessIdentifier thepid) ) || isvalidlocal )
   if isLocal node (NodeIdentifier atnode)
-     then do when (isOk) $
+     then do when isOk $
                do modify' $ registeredHereFor label ^= mPid
                   updateRemote node currentVal mPid
                   case mPid of
                     (Just p) -> liftIO $ trace node (MxRegistered p label)
                     Nothing  -> liftIO $ trace node (MxUnRegistered (fromJust currentVal) label)
+             newVal <- gets (^. registeredHereFor label)
              liftIO $ sendMessage node
                        (NodeIdentifier (localNodeId node))
                        (ProcessIdentifier from)
                        WithImplicitReconnect
-                       (RegisterReply label isOk)
+                       (RegisterReply label isOk newVal)
      else let operation =
                  case reregistration of
                     True -> flip decList


### PR DESCRIPTION
Now includes the identifier of the process that owns the name, if any.
The exception used to only mention the name. However, that made it
impossible to implement many algorithms, such as "return registered
process or spawn new one" in a race free way. If you catch
ProcessRegistrationException after attempting `register`, doing
`whereis` after that to find out who owns the name is racy.

This is a BREAKING CHANGE, albeit to a peripheral part of the current
API, so the next release of distributed-process that includes this
change will have to bump the major version number according to the PVP.

Needs companion patch to distributed-process-tests to pass CI successfully.