### PR TITLE
DP-02: simple approach for maintaining queue size.

### DIFF
--- a/src/Control/Distributed/Process/Internal/CQueue.hs
+++ b/src/Control/Distributed/Process/Internal/CQueue.hs
@@ -10,6 +10,7 @@ module Control.Distributed.Process.Internal.CQueue
   , enqueueSTM
   , dequeue
   , mkWeakCQueue
+  , queueSize 
   ) where
 
 import Prelude hiding (length, reverse)
@@ -17,10 +18,14 @@ import Control.Concurrent.STM
   ( atomically
   , STM
   , TChan
+  , TVar
+  , modifyTVar'
   , tryReadTChan
   , newTChan
+  , newTVarIO
   , writeTChan
   , readTChan
+  , readTVarIO
   , orElse
   , retry
   )
@@ -38,6 +43,7 @@ import Control.Distributed.Process.Internal.StrictList
   , append
   )
 import Data.Maybe (fromJust)
+import Data.Foldable (traverse_)
 import GHC.MVar (MVar(MVar))
 import GHC.IO (IO(IO))
 import GHC.Prim (mkWeak#)
@@ -46,19 +52,22 @@ import GHC.Weak (Weak(Weak))
 -- We use a TCHan rather than a Chan so that we have a non-blocking read
 data CQueue a = CQueue (StrictMVar (StrictList a)) -- Arrived
                        (TChan a)                   -- Incoming
+                       (TVar Int)                 -- Queue size
 
 newCQueue :: IO (CQueue a)
-newCQueue = CQueue <$> newMVar Nil <*> atomically newTChan
+newCQueue = CQueue <$> newMVar Nil <*> atomically newTChan <*> newTVarIO 0
 
 -- | Enqueue an element
 --
 -- Enqueue is strict.
 enqueue :: CQueue a -> a -> IO ()
-enqueue (CQueue _arrived incoming) !a = atomically $ writeTChan incoming a
+enqueue c !a = atomically (enqueueSTM c a)
 
 -- | Variant of enqueue for use in the STM monad.
 enqueueSTM :: CQueue a -> a -> STM ()
-enqueueSTM (CQueue _arrived incoming) !a = writeTChan incoming a
+enqueueSTM (CQueue _arrived incoming size) !a = do
+   writeTChan incoming a
+   modifyTVar' size succ
 
 data BlockSpec =
     NonBlocking
@@ -101,7 +110,7 @@ dequeue :: forall m a.
         -> BlockSpec         -- ^ Blocking behaviour
         -> [MatchOn m a]     -- ^ List of matches
         -> IO (Maybe a)      -- ^ 'Nothing' only on timeout
-dequeue (CQueue arrived incoming) blockSpec matchons =
+dequeue (CQueue arrived incoming size) blockSpec matchons = checkDecrement $
   case blockSpec of
     Timeout n -> timeout n $ fmap fromJust run
     _other    ->
@@ -113,6 +122,11 @@ dequeue (CQueue arrived incoming) blockSpec matchons =
                               -- no onException needed
          _other -> run
   where
+    checkDecrement f = do
+       mx <- f
+       mask_ $ traverse_ (const $ atomically $ modifyTVar' size pred) mx
+       return mx
+
     chunks = chunkMatches matchons
 
     run = mask_ $ do
@@ -245,5 +259,8 @@ dequeue (CQueue arrived incoming) blockSpec matchons =
 
 -- | Weak reference to a CQueue
 mkWeakCQueue :: CQueue a -> IO () -> IO (Weak (CQueue a))
-mkWeakCQueue m@(CQueue (StrictMVar (MVar m#)) _) f = IO $ \s ->
+mkWeakCQueue m@(CQueue (StrictMVar (MVar m#)) _ _) f = IO $ \s ->
   case mkWeak# m# m f s of (# s1, w #) -> (# s1, Weak w #)
+
+queueSize :: CQueue a -> IO Int
+queueSize (CQueue _ _ size) = readTVarIO size


### PR DESCRIPTION
This commit introduces basic approach to maintain size of the
queue by keeping TVar Int in the state, then each writer will
increment this state, and deque will decrement it if and only
if it outputs value.