### PR TITLE
Implement unreliable send (usend).

### DIFF
--- a/src/Control/Distributed/Process.hs
+++ b/src/Control/Distributed/Process.hs
@@ -25,6 +25,7 @@ module Control.Distributed.Process
   , liftIO -- Reexported for convenience
     -- * Basic messaging
   , send
+  , usend
   , expect
   , expectTimeout
     -- * Channels
@@ -195,6 +196,7 @@ import Control.Distributed.Process.Serializable (Serializable)
 import Control.Distributed.Process.Internal.Primitives
   ( -- Basic messaging
     send
+  , usend
   , expect
     -- Channels
   , newChan

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -255,11 +255,15 @@ send them msg = do
 unsafeSend :: Serializable a => ProcessId -> a -> Process ()
 unsafeSend = Unsafe.send
 
--- | Send a message without any reliability or ordering guarantees.
+-- | Send a message unreliably.
 --
 -- Unlike 'send', this function is insensitive to 'reconnect'. It will
 -- try to send the message regardless of the history of connection failures
 -- between the nodes.
+--
+-- Message passing with 'usend' is ordered for a given sender and receiver
+-- if the messages arrive at all.
+--
 usend :: Serializable a => ProcessId -> a -> Process ()
 usend them msg = do
     here <- getSelfNode

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -571,6 +571,7 @@ data ProcessSignal =
   | WhereIs !String
   | Register !String !NodeId !(Maybe ProcessId) !Bool -- Use 'Nothing' to unregister, use True to force reregister
   | NamedSend !String !Message
+  | UnreliableSend !LocalProcessId !Message
   | LocalSend !ProcessId !Message
   | LocalPortSend !SendPortId !Message
   | Kill !ProcessId !String
@@ -626,6 +627,7 @@ instance Binary ProcessSignal where
   put (Exit pid reason)       = putWord8 10 >> put pid >> put (messageToPayload reason)
   put (LocalSend to' msg)      = putWord8 11 >> put to' >> put (messageToPayload msg)
   put (LocalPortSend sid msg) = putWord8 12 >> put sid >> put (messageToPayload msg)
+  put (UnreliableSend lpid msg) = putWord8 13 >> put lpid >> put (messageToPayload msg)
   put (GetInfo about)         = putWord8 30 >> put about
   put (SigShutdown)         = putWord8 31
   put (GetNodeStats nid)         = putWord8 32 >> put nid
@@ -645,6 +647,7 @@ instance Binary ProcessSignal where
       10 -> Exit <$> get <*> (payloadToMessage <$> get)
       11 -> LocalSend <$> get <*> (payloadToMessage <$> get)
       12 -> LocalPortSend <$> get <*> (payloadToMessage <$> get)
+      13 -> UnreliableSend <$> get <*> (payloadToMessage <$> get)
       30 -> GetInfo <$> get
       31 -> return SigShutdown
       32 -> GetNodeStats <$> get

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -688,6 +688,8 @@ nodeController = do
         ncEffectWhereIs from label
       NCMsg _ (NamedSend label msg') ->
         ncEffectNamedSend label msg'
+      NCMsg _ (UnreliableSend lpid msg') ->
+        ncEffectLocalSend node (ProcessId (localNodeId node) lpid) msg'
       NCMsg _ (LocalSend to msg') ->
         ncEffectLocalSend node to msg'
       NCMsg _ (LocalPortSend to msg') ->
@@ -1062,6 +1064,7 @@ destNid (Spawn _ _)           = Nothing
 destNid (Register _ _ _ _)    = Nothing
 destNid (WhereIs _)           = Nothing
 destNid (NamedSend _ _)       = Nothing
+destNid (UnreliableSend _ _)  = Nothing
 -- We don't need to forward 'Died' signals; if monitoring/linking is setup,
 -- then when a local process dies the monitoring/linking machinery will take
 -- care of notifying remote nodes


### PR DESCRIPTION
Unlike `send`, the function `usend` is insensitive to `reconnect`. It will try to send the message regardless of the history of connection failures between the nodes.

It saves the tediousness of dealing with 'monitor' and 'reconnect' calls when reliability is not required.

The implementation mimics `nsendRemote`. The `msg` and the `pid` go together to the target node, and the target node dispatches the message to the target process.

When working in a network with failures, distributed algorithms sometimes don't have reliability or ordering requirements. Using `usend` saves many brain cycles that would be spent in figuring out what to `monitor` and when to call `reconnect`.

If this implementation is liked, we would add some tests for it in d-p-tests.

Maybe `UnreliableSend` and `LocalSend` could be conflated into one constructor. The only reason to have `UnreliableSend` is to spare the `NodeId` when sending the message remotely. `LocalSend` does not seem to use the `NodeId` for anything either.