### PR TITLE
Break feedback loop when tracing messages to the console.

### DIFF
--- a/src/Control/Distributed/Process/Management/Internal/Trace/Tracer.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Trace/Tracer.hs
@@ -146,7 +146,7 @@ systemLoggerTracer = do
       emptyPid <- return $ (nullProcessId (localNodeId node))
       traceMsg <- return $ NCMsg {
                              ctrlMsgSender = ProcessIdentifier (emptyPid)
-                           , ctrlMsgSignal = (NamedSend "logger"
+                           , ctrlMsgSignal = (NamedSend "trace.logger"
                                                  (createUnencodedMessage msg))
                            }
       liftIO $ writeChan (localCtrlChan node) traceMsg

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -295,7 +295,12 @@ startServiceProcesses node = do
   tableCoordinatorPid <- fork $ Table.startTableCoordinator fork
   runProcess node $ register Table.mxTableCoordinator tableCoordinatorPid
   logger <- forkProcess node loop
-  runProcess node $ register "logger" logger
+  runProcess node $ do
+    register "logger" logger
+    -- The trace.logger is used for tracing to the console to avoid feedback
+    -- loops during tracing if the user reregisters the "logger" with a custom
+    -- process which uses 'send' or other primitives which are traced.
+    register "trace.logger" logger
  where
    fork = forkProcess node
 


### PR DESCRIPTION
If the user reregisters the "logger" with a custom process which uses 'send' or other primitives which are traced, this primitives would produce tracing messages which would cause the primitives to be called
again.

This bug only affects tracing messages to the console with
```
DISTRIBUTED_PROCESS_TRACE_CONSOLE=y
DISTRIBUTED_PROCESS_TRACE_FLAGS=r
```

Test program:
```Haskell
{-# LANGUAGE BangPatterns #-}
import Control.Distributed.Process
import Control.Distributed.Process.Node
import Network.Transport.TCP

import Control.Monad
import System.Environment


main :: IO ()
main = do
  setEnv "DISTRIBUTED_PROCESS_TRACE_CONSOLE" "y"
  setEnv "DISTRIBUTED_PROCESS_TRACE_FLAGS" "r"
  Right transport <- createTransport "127.0.0.1" "8080" defaultTCPParameters
  lnode <- newLocalNode transport initRemoteTable
  runProcess lnode $ do
    self <- getSelfPid

    -- Register a logger which forwards messages to us and to the old
    -- logger.
    Just logger <- whereis "logger"
    newLogger   <- spawnLocal $ forever $ receiveWait
                     [ matchAny $ \m -> forward m logger >> forward m self ]
    reregister "logger" newLogger

    say "hello"

    -- Wait until there are no more messages for a while.
    let receiveMany !acc = do
          m <- receiveTimeout 1000000 [ matchAny $ const $ return () ]
          case m of
            Nothing -> return acc
            Just () -> receiveMany $ acc + 1

    receiveMany 0 >>= liftIO . print
```

Subscribers: @mboes, @qnikst 