### PR TITLE
A closeLocalNode that cleans up after itself

### DIFF
--- a/src/Control/Distributed/Process/Internal/Messaging.hs
+++ b/src/Control/Distributed/Process/Internal/Messaging.hs
@@ -114,7 +114,7 @@ setupConnBetween node from to implicitReconnect = do
           Left _ ->
             return Nothing
           Right () -> do
-            modifyValidLocalState_ (localState node) $
+            modifyValidLocalState_ node $
               return . (localConnectionBetween from to ^= Just (conn, implicitReconnect))
             return $ Just conn
       Left _ ->
@@ -126,7 +126,7 @@ connBetween :: LocalNode
             -> ImplicitReconnect
             -> IO (Maybe NT.Connection)
 connBetween node from to implicitReconnect = do
-    mConn <- withValidLocalState (localState node) $
+    mConn <- withValidLocalState node $
       return . (^. localConnectionBetween from to)
     case mConn of
       Just (conn, _) ->
@@ -136,7 +136,7 @@ connBetween node from to implicitReconnect = do
 
 disconnect :: LocalNode -> Identifier -> Identifier -> IO ()
 disconnect node from to =
-  modifyValidLocalState_ (localState node) $ \vst ->
+  modifyValidLocalState_ node $ \vst ->
     case vst ^. localConnectionBetween from to of
       Nothing ->
         return vst
@@ -146,7 +146,7 @@ disconnect node from to =
 
 closeImplicitReconnections :: LocalNode -> Identifier -> IO ()
 closeImplicitReconnections node to =
-  modifyValidLocalState_ (localState node) $ \vst -> do
+  modifyValidLocalState_ node $ \vst -> do
     let shouldClose (_, to') (_, WithImplicitReconnect) = to `impliesDeathOf` to'
         shouldClose _ _ = False
     let (affected, unaffected) =

--- a/src/Control/Distributed/Process/Internal/Messaging.hs
+++ b/src/Control/Distributed/Process/Internal/Messaging.hs
@@ -13,7 +13,6 @@ import Data.Binary (Binary, encode)
 import qualified Data.Map as Map (partitionWithKey, elems)
 import qualified Data.ByteString.Lazy as BSL (toChunks)
 import qualified Data.ByteString as BSS (ByteString)
-import Control.Distributed.Process.Internal.StrictMVar (withMVar, modifyMVar_)
 import Control.Distributed.Process.Serializable ()
 
 import Control.Concurrent.Chan (writeChan)
@@ -30,6 +29,8 @@ import qualified Network.Transport as NT
   )
 import Control.Distributed.Process.Internal.Types
   ( LocalNode(localState, localEndPoint, localCtrlChan)
+  , withValidLocalState
+  , modifyValidLocalState_
   , Identifier
   , localConnections
   , localConnectionBetween
@@ -102,7 +103,7 @@ setupConnBetween :: LocalNode
                  -> ImplicitReconnect
                  -> IO (Maybe NT.Connection)
 setupConnBetween node from to implicitReconnect = do
-    mConn <- NT.connect endPoint
+    mConn <- NT.connect (localEndPoint node)
                         (nodeAddress . nodeOf $ to)
                         NT.ReliableOrdered
                         NT.defaultConnectHints
@@ -113,14 +114,11 @@ setupConnBetween node from to implicitReconnect = do
           Left _ ->
             return Nothing
           Right () -> do
-            modifyMVar_ nodeState $ return .
-              (localConnectionBetween from to ^= Just (conn, implicitReconnect))
+            modifyValidLocalState_ (localState node) $
+              return . (localConnectionBetween from to ^= Just (conn, implicitReconnect))
             return $ Just conn
       Left _ ->
         return Nothing
-  where
-    endPoint  = localEndPoint node
-    nodeState = localState node
 
 connBetween :: LocalNode
             -> Identifier
@@ -128,33 +126,33 @@ connBetween :: LocalNode
             -> ImplicitReconnect
             -> IO (Maybe NT.Connection)
 connBetween node from to implicitReconnect = do
-    mConn <- withMVar nodeState $ return . (^. localConnectionBetween from to)
+    mConn <- withValidLocalState (localState node) $
+      return . (^. localConnectionBetween from to)
     case mConn of
       Just (conn, _) ->
         return $ Just conn
       Nothing ->
         setupConnBetween node from to implicitReconnect
-  where
-    nodeState = localState node
 
 disconnect :: LocalNode -> Identifier -> Identifier -> IO ()
 disconnect node from to =
-  modifyMVar_ (localState node) $ \st ->
-    case st ^. localConnectionBetween from to of
+  modifyValidLocalState_ (localState node) $ \vst ->
+    case vst ^. localConnectionBetween from to of
       Nothing ->
-        return st
+        return vst
       Just (conn, _) -> do
         NT.close conn
-        return (localConnectionBetween from to ^= Nothing $ st)
+        return $ localConnectionBetween from to ^= Nothing $ vst
 
 closeImplicitReconnections :: LocalNode -> Identifier -> IO ()
 closeImplicitReconnections node to =
-  modifyMVar_ (localState node) $ \st -> do
+  modifyValidLocalState_ (localState node) $ \vst -> do
     let shouldClose (_, to') (_, WithImplicitReconnect) = to `impliesDeathOf` to'
         shouldClose _ _ = False
-    let (affected, unaffected) = Map.partitionWithKey shouldClose (st ^. localConnections)
+    let (affected, unaffected) =
+          Map.partitionWithKey shouldClose (vst ^. localConnections)
     mapM_ (NT.close . fst) (Map.elems affected)
-    return (localConnections ^= unaffected $ st)
+    return $ localConnections ^= unaffected $ vst
 
 -- | @a `impliesDeathOf` b@ is true if the death of @a@ (for instance, a node)
 -- implies the death of @b@ (for instance, a process on that node)

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -279,21 +279,21 @@ data ValidLocalNodeState = ValidLocalNodeState
 
 -- | Wrapper around 'withMVar' that checks that the local node is still in
 -- a valid state.
-withValidLocalState :: StrictMVar LocalNodeState
+withValidLocalState :: LocalNode
                     -> (ValidLocalNodeState -> IO r)
                     -> IO r
-withValidLocalState mv f = withMVar mv $ \st -> case st of
+withValidLocalState node f = withMVar (localState node) $ \st -> case st of
     LocalNodeValid vst -> f vst
-    LocalNodeClosed -> throwIO $ userError "LocalNode closed"
+    LocalNodeClosed -> throwIO $ userError $ "Node closed " ++ show (localNodeId node)
 
 -- | Wrapper around 'modifyMVar_' that checks that the local node is still in
 -- a valid state.
-modifyValidLocalState_ :: StrictMVar LocalNodeState
+modifyValidLocalState_ :: LocalNode
                        -> (ValidLocalNodeState -> IO ValidLocalNodeState)
                        -> IO ()
-modifyValidLocalState_ mv f = modifyMVar_ mv $ \st -> case st of
+modifyValidLocalState_ node f = modifyMVar_ (localState node) $ \st -> case st of
     LocalNodeValid vst -> LocalNodeValid <$> f vst
-    LocalNodeClosed -> throwIO $ userError "LocalNode closed"
+    LocalNodeClosed -> throwIO $ userError $ "Node closed " ++ show (localNodeId node)
 
 -- | Processes running on our local node
 data LocalProcess = LocalProcess

--- a/src/Control/Distributed/Process/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Internal/Types.hs
@@ -293,7 +293,7 @@ modifyValidLocalState_ :: LocalNode
                        -> IO ()
 modifyValidLocalState_ node f = modifyMVar_ (localState node) $ \st -> case st of
     LocalNodeValid vst -> LocalNodeValid <$> f vst
-    LocalNodeClosed -> throwIO $ userError $ "Node closed " ++ show (localNodeId node)
+    LocalNodeClosed -> return LocalNodeClosed
 
 -- | Processes running on our local node
 data LocalProcess = LocalProcess

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -414,7 +414,7 @@ forkProcess node proc =
                  $ vst
                  , pid
                  )
-    startProcess LocalNodeClosed = throwIO $ userError "LocalNode closed"
+    startProcess LocalNodeClosed = throwIO $ userError $ "Node closed " ++ show (localNodeId node)
 
     cleanupProcess :: ProcessId -> ValidLocalNodeState -> IO ValidLocalNodeState
     cleanupProcess pid vst = do

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -76,7 +76,6 @@ import Control.Distributed.Process.Internal.StrictMVar
   , newEmptyMVar
   , putMVar
   , takeMVar
-  , readMVar
   )
 import Control.Concurrent.Chan (newChan, writeChan, readChan)
 import qualified Control.Concurrent.MVar as MVar (newEmptyMVar, takeMVar)
@@ -119,6 +118,9 @@ import Control.Distributed.Process.Internal.Types
   , LocalNode(..)
   , MxEventBus(..)
   , LocalNodeState(..)
+  , ValidLocalNodeState(..)
+  , withValidLocalState
+  , modifyValidLocalState_
   , LocalProcess(..)
   , LocalProcessState(..)
   , Process(..)
@@ -231,7 +233,7 @@ newLocalNode transport rtable = do
 createBareLocalNode :: NT.EndPoint -> RemoteTable -> IO LocalNode
 createBareLocalNode endPoint rtable = do
     unq <- randomIO
-    state <- newMVar LocalNodeState
+    state <- newMVar $ LocalNodeValid $ ValidLocalNodeState
       { _localProcesses   = Map.empty
       , _localPidCounter  = firstNonReservedProcessId
       , _localPidUnique   = unq
@@ -322,7 +324,8 @@ startServiceProcesses node = do
 --
 -- TODO: for now we just close the associated endpoint
 closeLocalNode :: LocalNode -> IO ()
-closeLocalNode node =
+closeLocalNode node = do
+  modifyMVar_ (localState node) $ const $ return LocalNodeClosed
   -- TODO: close all our processes, surely!?
   NT.closeEndPoint (localEndPoint node)
 
@@ -342,9 +345,9 @@ forkProcess node proc =
     modifyMVarMasked (localState node) startProcess
   where
     startProcess :: LocalNodeState -> IO (LocalNodeState, ProcessId)
-    startProcess st = do
-      let lpid  = LocalProcessId { lpidCounter = st ^. localPidCounter
-                                 , lpidUnique  = st ^. localPidUnique
+    startProcess (LocalNodeValid vst) = do
+      let lpid  = LocalProcessId { lpidCounter = vst ^. localPidCounter
+                                 , lpidUnique  = vst ^. localPidUnique
                                  }
       let pid   = ProcessId { processNodeId  = localNodeId node
                             , processLocalId = lpid
@@ -376,7 +379,7 @@ forkProcess node proc =
                 (return . DiedException . (show :: SomeException -> String)))]
 
           -- [Unified: Table 4, rules termination and exiting]
-          modifyMVar_ (localState node) (cleanupProcess pid)
+          modifyValidLocalState_ (localState node) (cleanupProcess pid)
           writeChan (localCtrlChan node) NCMsg
             { ctrlMsgSender = ProcessIdentifier pid
             , ctrlMsgSignal = Died (ProcessIdentifier pid) reason
@@ -391,27 +394,30 @@ forkProcess node proc =
           -- TODO: this doesn't look right at all - how do we know
           -- that newUnique represents a process id that is available!?
           newUnique <- randomIO
-          return ( (localProcessWithId lpid ^= Just lproc)
+          return ( LocalNodeValid
+                 $ (localProcessWithId lpid ^= Just lproc)
                  . (localPidCounter ^= firstNonReservedProcessId)
                  . (localPidUnique ^= newUnique)
-                 $ st
+                 $ vst
                  , pid
                  )
         else
-          return ( (localProcessWithId lpid ^= Just lproc)
+          return ( LocalNodeValid
+                 $ (localProcessWithId lpid ^= Just lproc)
                  . (localPidCounter ^: (+ 1))
-                 $ st
+                 $ vst
                  , pid
                  )
+    startProcess LocalNodeClosed = throwIO $ userError "LocalNode closed"
 
-    cleanupProcess :: ProcessId -> LocalNodeState -> IO LocalNodeState
-    cleanupProcess pid st = do
+    cleanupProcess :: ProcessId -> ValidLocalNodeState -> IO ValidLocalNodeState
+    cleanupProcess pid vst = do
       let pid' = ProcessIdentifier pid
-      let (affected, unaffected) = Map.partitionWithKey (\(fr, _to) !_v -> impliesDeathOf pid' fr) (st ^. localConnections)
+      let (affected, unaffected) = Map.partitionWithKey (\(fr, _to) !_v -> impliesDeathOf pid' fr) (vst ^. localConnections)
       mapM_ (NT.close . fst) (Map.elems affected)
       return $ (localProcessWithId (processLocalId pid) ^= Nothing)
              . (localConnections ^= unaffected)
-             $ st
+             $ vst
 
 -- note [tracer/forkProcess races]
 --
@@ -500,7 +506,7 @@ handleIncomingMessages node = go initConnectionState
               case decode (BSL.fromChunks payload) of
                 ProcessIdentifier pid -> do
                   let lpid = processLocalId pid
-                  mProc <- withMVar state $ return . (^. localProcessWithId lpid)
+                  mProc <- withValidLocalState state $ return . (^. localProcessWithId lpid)
                   case mProc of
                     Just proc ->
                       go (incomingAt cid ^= Just (src, ToProc pid (processWeakQ proc)) $ st)
@@ -509,7 +515,7 @@ handleIncomingMessages node = go initConnectionState
                 SendPortIdentifier chId -> do
                   let lcid = sendPortLocalId chId
                       lpid = processLocalId (sendPortProcessId chId)
-                  mProc <- withMVar state $ return . (^. localProcessWithId lpid)
+                  mProc <- withValidLocalState state $ return . (^. localProcessWithId lpid)
                   case mProc of
                     Just proc -> do
                       mChannel <- withMVar (processState proc) $ return . (^. typedChannelWithId lcid)
@@ -970,8 +976,8 @@ ncEffectGetInfo from pid =
       them = (ProcessIdentifier pid)
   in do
   node <- ask
-  mProc <- liftIO $
-            withMVar (localState node) $ return . (^. localProcessWithId lpid)
+  mProc <- liftIO $ withValidLocalState (localState node)
+                  $ return . (^. localProcessWithId lpid)
   case mProc of
     Nothing   -> dispatch (isLocal node (ProcessIdentifier from))
                           from node (ProcessInfoNone DiedUnknownId)
@@ -1014,17 +1020,17 @@ ncEffectGetNodeStats :: ProcessId -> NodeId -> NC ()
 ncEffectGetNodeStats from _nid = do
   node <- ask
   ncState <- StateT.get
-  nodeState <- liftIO $ readMVar (localState node)
-  let localProcesses' = nodeState ^. localProcesses
-      stats =
+  nodeState <- liftIO $ withValidLocalState (localState node) return
+  let stats =
         NodeStats {
             nodeStatsNode = localNodeId node
           , nodeStatsRegisteredNames = Map.size $ ncState ^. registeredHere
           , nodeStatsMonitors = Map.size $ ncState ^. monitors
           , nodeStatsLinks = Map.size $ ncState ^. links
-          , nodeStatsProcesses = Map.size localProcesses'
+          , nodeStatsProcesses = Map.size (nodeState ^. localProcesses)
           }
   postAsMessage from stats
+
 --------------------------------------------------------------------------------
 -- Auxiliary                                                                  --
 --------------------------------------------------------------------------------
@@ -1097,7 +1103,7 @@ unClosure closure = do
 isValidLocalIdentifier :: Identifier -> NC Bool
 isValidLocalIdentifier ident = do
   node <- ask
-  liftIO . withMVar (localState node) $ \nSt ->
+  liftIO . withValidLocalState (localState node) $ \nSt ->
     case ident of
       NodeIdentifier nid ->
         return $ nid == localNodeId node
@@ -1135,8 +1141,8 @@ withLocalProc node pid p =
   -- By [Unified: table 6, rule missing_process] messages to dead processes
   -- can silently be dropped
   let lpid = processLocalId pid in do
-  mProc <- withMVar (localState node) $ return . (^. localProcessWithId lpid)
-  forM_ mProc p
+  withValidLocalState (localState node) $ \vst ->
+    forM_ (vst ^. localProcessWithId lpid) p
 
 --------------------------------------------------------------------------------
 -- Accessors                                                                  --

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -333,6 +333,8 @@ closeLocalNode node = do
         killThread (processThread lproc)
       return LocalNodeClosed
     LocalNodeClosed -> return LocalNodeClosed
+  -- This call will have the effect of shutting down the NC as well (see
+  -- 'createBareLocalNode').
   NT.closeEndPoint (localEndPoint node)
 
 -- | Run a process on a local node and wait for it to finish

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -323,6 +323,7 @@ startServiceProcesses node = do
 -- | Force-close a local node, killing all processes on that node.
 closeLocalNode :: LocalNode -> IO ()
 closeLocalNode node = do
+  modifyMVar_ (localState node) $ const $ return LocalNodeClosed
   withValidLocalState (localState node) $ \vst ->
     forM_ (vst ^. localProcesses) $ \lproc ->
       -- Semantics of 'throwTo' guarantee that target thread will get delivered
@@ -330,7 +331,6 @@ closeLocalNode node = do
       -- that's as good as we can do. No need to wait for thread to actually
       -- finish dying.
       killThread (processThread lproc)
-  modifyMVar_ (localState node) $ const $ return LocalNodeClosed
   NT.closeEndPoint (localEndPoint node)
 
 -- | Run a process on a local node and wait for it to finish


### PR DESCRIPTION
`closeLocalNode` currently closes the network-transport endpoint, but that's about it. Processes that run on the given node still run, it's just that they can no longer be contacted via a network-transport connection. In this PR, we take a page from network-transport-tcp's book and define a node as having two possible states: "valid" and "closed". A node in the "closed" state is defunct, so all resources associated with it can be freed. Moreover, no new processes can be spawned on a closed node without raising an exception.

This PR is an alternative to #187.

Ping @qnikst you said you had tests for this?

Ping @facundominguez 