### PR TITLE
Revert "Named send is intra-node, so we can use the optimised routing / encoding"

### DIFF
--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -1130,7 +1130,7 @@ whereisRemoteAsync nid label =
 -- | Named send to a process in the local registry (asynchronous)
 nsend :: Serializable a => String -> a -> Process ()
 nsend label msg =
-  sendCtrlMsg Nothing (NamedSend label (createUnencodedMessage msg))
+  sendCtrlMsg Nothing (NamedSend label (createMessage msg))
 
 -- | Named send to a process in the local registry (asynchronous).
 -- This function makes /no/ attempt to serialize and (in the case when the


### PR DESCRIPTION
This reverts commit 9f10533cc0edd741f6472157d581d4b8e9e0bf2c.

In distributed-process it's possible to keep remote values in registry, commit 9f10533c
broke that functionality.