### PR TITLE
Make 'sendCtrlMsg' strict in the local case.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Messaging.hs
+++ b/src/Control/Distributed/Process/Internal/Messaging.hs
@@ -177,7 +177,11 @@ _ `impliesDeathOf` _ =
   False
 
 
--- Send a control message
+-- Send a control message. Evaluates the message to HNF before sending it.
+--
+-- The message shouldn't produce more errors when further evaluated. If
+-- evaluation threw errors the node controller or the receiver would crash when
+-- inspecting it.
 sendCtrlMsg :: Maybe NodeId  -- ^ Nothing for the local node
             -> ProcessSignal -- ^ Message to send
             -> Process ()
@@ -188,7 +192,7 @@ sendCtrlMsg mNid signal = do
                   }
   case mNid of
     Nothing -> do
-      liftIO $ writeChan (localCtrlChan (processNode proc)) msg
+      liftIO $ writeChan (localCtrlChan (processNode proc)) $! msg
     Just nid ->
       liftIO $ sendBinary (processNode proc)
                           (ProcessIdentifier (processId proc))


### PR DESCRIPTION
Now it evaluates the input message to HNF. If left non-strict, the NC would stop when evaluating a message fails or blocks.

It is still possible to crash the NC if deeper evaluation of the message produces errors. For this sake we make a precondition of 'sendCtrlMsg' that further evaluation of the message should not produce errors in the local case.