### PR TITLE
Add Functor instance for Match data type

### DIFF
--- a/src/Control/Distributed/Process/Internal/CQueue.hs
+++ b/src/Control/Distributed/Process/Internal/CQueue.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards, ScopedTypeVariables, RankNTypes #-}
 -- | Concurrent queue for single reader, single writer
@@ -77,6 +78,7 @@ data BlockSpec =
 data MatchOn m a
  = MatchMsg  (m -> Maybe a)
  | MatchChan (STM a)
+ deriving (Functor)
 
 type MatchChunks m a = [Either [m -> Maybe a] [STM a]]
 

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP  #-}
 {-# LANGUAGE RankNTypes  #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE BangPatterns #-}
@@ -374,6 +375,7 @@ mergePortsRR = \ps -> do
 
 -- | Opaque type used in 'receiveWait' and 'receiveTimeout'
 newtype Match b = Match { unMatch :: MatchOn Message (Process b) }
+                  deriving (Functor)
 
 -- | Test the matches in order against each message in the queue
 receiveWait :: [Match b] -> Process b


### PR DESCRIPTION
Main use of that instance is to allow composition of `Match`es of different type:

```.haskell
receiveWait
  [ Left <$> (match :: Match a)
  , Right <$> (match :: Match b)
  ]
```

It's not always convenient/possible to set types of Match right at construction time and I don't see any compelling reason to not add this instance