### PR TITLE
Fix error case in node connection procedure.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Messaging.hs
+++ b/src/Control/Distributed/Process/Internal/Messaging.hs
@@ -74,7 +74,7 @@ sendPayload node from to implicitReconnect payload = do
   unless didSend $ do
     writeChan (localCtrlChan node) NCMsg
       { ctrlMsgSender = to
-      , ctrlMsgSignal = Died to DiedDisconnect
+      , ctrlMsgSignal = Died (NodeIdentifier $ nodeOf to) DiedDisconnect
       }
 
 sendBinary :: Binary a


### PR DESCRIPTION
In case if new connection to remote EndPoint failed to create,
this means that all reliable connections (that are used in d-p)
also failed. As a result this means that we need to emit
`Died (node) Disconnect` event. Previously we emited
`Died typeOfReceiver Disconnect` event.