### PR TITLE
fixup! Avoid racy blocking behavior in closeLocalNode.

### DIFF
--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -53,7 +53,7 @@ import Data.Maybe (isJust, fromJust, isNothing, catMaybes)
 import Data.Typeable (Typeable)
 import Control.Category ((>>>))
 import Control.Applicative (Applicative, (<$>))
-import Control.Monad (void, when)
+import Control.Monad (void, when, join)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.State.Strict (MonadState, StateT, evalStateT, gets)
 import qualified Control.Monad.State.Strict as StateT (get, put)
@@ -78,6 +78,7 @@ import Control.Distributed.Process.Internal.StrictMVar
   , withMVar
   , modifyMVarMasked
   , modifyMVar_
+  , modifyMVar
   , newEmptyMVar
   , putMVar
   , takeMVar


### PR DESCRIPTION
cloud haskell CI complains about:
```
    src/Control/Distributed/Process/Node.hs:338:3: Not in scope: ‘join’

    src/Control/Distributed/Process/Node.hs:338:10:
        Not in scope: ‘modifyMVar’
        Perhaps you meant ‘modifyMVar_’ (imported from Control.Distributed.Process.Internal.StrictMVar)
```

https://travis-ci.org/haskell-distributed/cloud-haskell

This patch fixes that.