### PR TITLE
Make CI build package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
   - cabal install --only-dependencies
 
 script:
-  - cabal configure --enable-tests
-  - cabal test --show-details=always
+  - cabal configure
+  - cabal build


### PR DESCRIPTION
Distributed-process package contains no test suites. As a result
cabal test command does nothing. This commit run cabal build, so
CI will check at least build failures.