### PR TITLE
Throw NodeClosedException when the node controller is stopped.

### DIFF
--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -765,8 +765,7 @@ nodeController = do
       NCMsg _ SigShutdown ->
         liftIO $ do
           NT.closeEndPoint (localEndPoint node)
-            `Exception.finally` throwIO ThreadKilled
-        -- ThreadKilled seems to make more sense than fail/error here
+            `Exception.finally` throwIO (NodeClosedException $ localNodeId node)
       NCMsg (ProcessIdentifier from) (GetNodeStats nid) ->
         ncEffectGetNodeStats from nid
       unexpected ->


### PR DESCRIPTION
Formerly the NC could end with either `NodeClosedException` or with `ThreadKilled`. ThreadKilled was a bit confusing because there is no call to `threadKill` to send it and there was no good reason to prefer it over `NodeClosedException`.