### PR TITLE
add withMonitorRef primitive.

### DIFF
--- a/src/Control/Distributed/Process.hs
+++ b/src/Control/Distributed/Process.hs
@@ -102,6 +102,7 @@ module Control.Distributed.Process
   , monitorPort
   , unmonitor
   , withMonitor
+  , withMonitorRef
   , MonitorRef -- opaque
   , ProcessLinkException(..)
   , NodeLinkException(..)
@@ -267,6 +268,7 @@ import Control.Distributed.Process.Internal.Primitives
   , monitorPort
   , unmonitor
   , withMonitor
+  , withMonitorRef
     -- Logging
   , say
     -- Registry

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -77,6 +77,7 @@ module Control.Distributed.Process.Internal.Primitives
   , monitor
   , unmonitor
   , withMonitor
+  , withMonitorRef
     -- * Logging
   , say
     -- * Registry
@@ -887,11 +888,20 @@ monitor = monitor' . ProcessIdentifier
 -- messages in the queue.
 --
 withMonitor :: ProcessId -> Process a -> Process a
-withMonitor pid code = bracket (monitor pid) unmonitor (\_ -> code)
+withMonitor pid = withMonitorRef pid . const
   -- unmonitor blocks waiting for the response, so there's a possibility
   -- that an exception might interrupt withMonitor before the unmonitor
   -- has completed.  I think that's better than making the unmonitor
   -- uninterruptible.
+
+-- | Establishes temporary monitoring of another process.
+--
+-- @withMonitorRef pid code@ sets up monitoring of @pid@ for the duration
+-- of @code@.  Note: although monitoring is no longer active when
+-- @withMonitorRef@ returns, there might still be unreceived monitor
+-- messages in the queue.
+withMonitorRef :: ProcessId -> (MonitorRef -> Process a) -> Process a
+withMonitorRef pid code = bracket (monitor pid) unmonitor code
 
 -- | Remove a link
 --


### PR DESCRIPTION
withMonitorRef works like withMonitor but gives access to allocated
MonitorRef, so user could use it in Matches.