### PR TITLE
With monitor ref

### DIFF
--- a/src/Control/Distributed/Process.hs
+++ b/src/Control/Distributed/Process.hs
@@ -102,7 +102,7 @@ module Control.Distributed.Process
   , monitorPort
   , unmonitor
   , withMonitor
-  , withMonitorRef
+  , withMonitor_
   , MonitorRef -- opaque
   , ProcessLinkException(..)
   , NodeLinkException(..)
@@ -270,7 +270,7 @@ import Control.Distributed.Process.Internal.Primitives
   , monitorPort
   , unmonitor
   , withMonitor
-  , withMonitorRef
+  , withMonitor_
     -- Logging
   , say
     -- Registry

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -887,9 +887,8 @@ monitor = monitor' . ProcessIdentifier
 -- @withMonitor@ returns, there might still be unreceived monitor
 -- messages in the queue.
 --
-withMonitor :: ProcessId -> Process a -> Process a
-withMonitor pid = bracket (monitor pid) unmonitor . const
-{-# WARNING withMonitor "Signature of this function will be changed to 'ProcessId -> (MonitorRef -> Process a) -> Process a' in the next release, for stable behaviour use withMonitor_" #-}
+withMonitor :: ProcessId -> (MonitorRef -> Process a) -> Process a
+withMonitor pid = bracket (monitor pid) unmonitor
 
 -- | Establishes temporary monitoring of another process.
 --
@@ -900,7 +899,7 @@ withMonitor pid = bracket (monitor pid) unmonitor . const
 --
 -- Since 0.6.1
 withMonitor_ :: ProcessId -> Process a -> Process a
-withMonitor_ = withMonitor
+withMonitor_ p = withMonitor p . const
 
 -- | Remove a link
 --

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -77,7 +77,7 @@ module Control.Distributed.Process.Internal.Primitives
   , monitor
   , unmonitor
   , withMonitor
-  , withMonitorRef
+  , withMonitor_
     -- * Logging
   , say
     -- * Registry
@@ -888,20 +888,19 @@ monitor = monitor' . ProcessIdentifier
 -- messages in the queue.
 --
 withMonitor :: ProcessId -> Process a -> Process a
-withMonitor pid = withMonitorRef pid . const
-  -- unmonitor blocks waiting for the response, so there's a possibility
-  -- that an exception might interrupt withMonitor before the unmonitor
-  -- has completed.  I think that's better than making the unmonitor
-  -- uninterruptible.
+withMonitor pid = bracket (monitor pid) unmonitor . const
+{-# WARNING withMonitor "Signature of this function will be changed to 'ProcessId -> (MonitorRef -> Process a) -> Process a' in the next release, for stable behaviour use withMonitor_" #-}
 
 -- | Establishes temporary monitoring of another process.
 --
--- @withMonitorRef pid code@ sets up monitoring of @pid@ for the duration
--- of @code@.  Note: although monitoring is no longer active when
--- @withMonitorRef@ returns, there might still be unreceived monitor
+-- @withMonitor_ pid code@ sets up monitoring of @pid@ for the duration
+-- of @code@. Note: although monitoring is no longer active when
+-- @withMonitor_@ returns, there might still be unreceived monitor
 -- messages in the queue.
-withMonitorRef :: ProcessId -> (MonitorRef -> Process a) -> Process a
-withMonitorRef pid code = bracket (monitor pid) unmonitor code
+--
+-- Since 0.6.1
+withMonitor_ :: ProcessId -> Process a -> Process a
+withMonitor_ = withMonitor
 
 -- | Remove a link
 --


### PR DESCRIPTION
Alternative approach to with monitor ref here we change withMonitor to have monitor ref and are introducing withMonitor_ for old behaviour. If we need to support compatible version - we could fork from d51d1e0.