### PR TITLE
Adapt to GHC 8.0 interface changes

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -42,7 +42,7 @@ flag old-locale
 
 Library
   Build-Depends:     base >= 4.4 && < 5,
-                     binary >= 0.6.3 && < 0.8,
+                     binary >= 0.6.3 && < 0.9,
                      hashable >= 1.2.0.5 && < 1.3,
                      network-transport >= 0.4.1.0 && < 0.5,
                      stm >= 2.4 && < 2.5,
@@ -109,7 +109,7 @@ benchmark distributed-process-throughput
                    distributed-process,
                    network-transport-tcp >= 0.3 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   binary >= 0.6.3 && < 0.8
+                   binary >= 0.6.3 && < 0.9
   Main-Is:         benchmarks/Throughput.hs
   ghc-options:     -Wall
 
@@ -119,7 +119,7 @@ benchmark distributed-process-latency
                    distributed-process,
                    network-transport-tcp >= 0.3 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   binary >= 0.6.3 && < 0.8
+                   binary >= 0.6.3 && < 0.9
   Main-Is:         benchmarks/Latency.hs
   ghc-options:     -Wall
 
@@ -129,7 +129,7 @@ benchmark distributed-process-channels
                    distributed-process,
                    network-transport-tcp >= 0.3 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   binary >= 0.6.3 && < 0.8
+                   binary >= 0.6.3 && < 0.9
   Main-Is:         benchmarks/Channels.hs
   ghc-options:     -Wall
 
@@ -139,7 +139,7 @@ benchmark distributed-process-spawns
                    distributed-process,
                    network-transport-tcp >= 0.3 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   binary >= 0.6.3 && < 0.8
+                   binary >= 0.6.3 && < 0.9
   Main-Is:         benchmarks/Spawns.hs
   ghc-options:     -Wall
 
@@ -149,6 +149,6 @@ benchmark distributed-process-ring
                    distributed-process,
                    network-transport-tcp >= 0.3 && < 0.6,
                    bytestring >= 0.9 && < 0.11,
-                   binary >= 0.6.3 && < 0.8
+                   binary >= 0.6.3 && < 0.9
   Main-Is:         benchmarks/ProcessRing.hs
   ghc-options:     -Wall -threaded -O2 -rtsopts

--- a/src/Control/Distributed/Process/Internal/Closure/TH.hs
+++ b/src/Control/Distributed/Process/Internal/Closure/TH.hs
@@ -299,7 +299,11 @@ getType :: Name -> Q (Name, Type)
 getType name = do
   info <- reify name
   case info of
+#if MIN_VERSION_template_haskell(2,11,0)
+    VarI origName typ _   -> return (origName, typ)
+#else
     VarI origName typ _ _ -> return (origName, typ)
+#endif
     _                     -> fail $ show name ++ " not found"
 
 -- | Variation on 'funD' which takes a single expression to define the function


### PR DESCRIPTION
 * `mkWeak#` now expects a raw state transformer instead of a boxed `IO` action.
 * the `template-haskell` `VarI` constructor has lost a field