### PR TITLE
Say: Send unformatted time over the wire

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-07-06 Facundo Domínguez <facundo.dominguez@tweag.io> 0.7.0
+
+* Change type of message sent by `say` from a 3-tuple to a proper
+type (`SayMessage`) with a proper `UTCTime`.
+
 2016-06-09 Facundo Domínguez <facundo.dominguez@tweag.io> 0.6.4
 
 * Fixup build errors.

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -37,6 +37,12 @@ import qualified Data.Map as Map
   , filterWithKey
   , foldlWithKey
   )
+import Data.Time.Format (formatTime)
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+#endif
 import Data.Set (Set)
 import qualified Data.Set as Set
   ( empty
@@ -200,6 +206,7 @@ import Control.Distributed.Process.Internal.Primitives
   , match
   , sendChan
   , unwrapMessage
+  , SayMessage(..)
   )
 import Control.Distributed.Process.Internal.Types (SendPort, Tracer(..))
 import qualified Control.Distributed.Process.Internal.Closure.BuiltIn as BuiltIn (remoteTable)
@@ -317,8 +324,9 @@ startServiceProcesses node = do
  where
    loop = do
      receiveWait
-       [ match $ \((time, pid, string) ::(String, ProcessId, String)) -> do
-           liftIO . hPutStrLn stderr $ time ++ " " ++ show pid ++ ": " ++ string
+       [ match $ \(SayMessage time pid string) -> do
+           let time' = formatTime defaultTimeLocale "%c" time
+           liftIO . hPutStrLn stderr $ time' ++ " " ++ show pid ++ ": " ++ string
            loop
        , match $ \((time, string) :: (String, String)) -> do
            -- this is a 'trace' message from the local node tracer


### PR DESCRIPTION
It's not clear why this function was designed as it was but it makes it
very difficult to feed messages from `say` to a proper logging
framework.

Unfortunately, it's not clear how to push out this sort of change 
without silently breaking user code due to the untyped nature of
 message passing. Thoughts?