### PR TITLE
Clear monitors in case when monitoring process dies.

### DIFF
--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -889,7 +889,7 @@ ncEffectDied ident reason = do
       when (localOnly <= isLocal node (ProcessIdentifier us)) $
         notifyDied us them reason (Just ref)
       modify' $ revMonitorsFor us ^: Set.delete (them, ref)
-  
+
   case ident of
     ProcessIdentifier pid -> do
       removedLinks <- gets (^. revLinksFor pid)


### PR DESCRIPTION
Assume situation when process A monitors process B. In this case
infomation about this is stored in node controller (NC).
Now when process A dies, we need to remove this information from NC
state. Otherwise we may have a memory leak when many short lived
processes monitors long lived process.

In this commit this logic is implemented - when process dies NC
traverses information about monitors and removes monitors allocated
by the process that died.