### PR TITLE
Use only one connection to communicate with NCs.

### DIFF
--- a/src/Control/Distributed/Process/Internal/Messaging.hs
+++ b/src/Control/Distributed/Process/Internal/Messaging.hs
@@ -201,7 +201,7 @@ sendCtrlMsg mNid signal = do
       liftIO $ writeChan (localCtrlChan (processNode proc)) $! msg
     Just nid ->
       liftIO $ sendBinary (processNode proc)
-                          (ProcessIdentifier (processId proc))
+                          (NodeIdentifier (processNodeId $ processId proc))
                           (NodeIdentifier nid)
                           WithImplicitReconnect
                           msg


### PR DESCRIPTION
This avoids connections from processes to nodes, which are never released for long-running processes. Given the implicit reconnections considered in the semantics for connections to/from node controllers, this change wouldn't alter the expected behavior of primitives.