### PR TITLE
relax upper bounds a little more

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -45,7 +45,7 @@ Library
                      binary >= 0.6.3 && < 0.10,
                      hashable >= 1.2.0.5 && < 1.3,
                      network-transport >= 0.4.1.0 && < 0.6,
-                     stm >= 2.4 && < 2.5,
+                     stm >= 2.4 && < 2.6,
                      transformers >= 0.2 && < 0.6,
                      mtl >= 2.0 && < 2.4,
                      data-accessor >= 0.2 && < 0.3,
@@ -55,7 +55,7 @@ Library
                      rank1dynamic >= 0.1 && < 0.5,
                      syb >= 0.3 && < 0.8,
                      exceptions >= 0.5,
-                     containers >= 0.5 && < 0.6,
+                     containers >= 0.5 && < 0.7,
                      deepseq >= 1.3.0.1 && < 1.6
   Exposed-modules:   Control.Distributed.Process,
                      Control.Distributed.Process.Closure,


### PR DESCRIPTION
This is required to get downstream libraries (such as distributed-process-{task, execution, fsm} etc) to build in travis with a new-ish stack release (e.g. lts-11.13). Without it we hit errors such as the following:

```
Error: While constructing the build
plan, the following exceptions were
encountered:
In the dependencies
for distributed-process-0.7.4:
    containers-0.6.0.1 from stack
                       configuration
                       does not
                       match >=0.5 && <0.6 
                       (latest matching
                       version
                       is 0.5.11.0)
    stm-2.5.0.0 from stack configuration
                does not
                match >=2.4 && <2.5 
                (latest matching version
                is 2.4.5.1)
needed due
to distributed-process-fsm-0.0.1
    -> distributed-process-0.7.4
```