### PR TITLE
make it possible to verify against latest snapshot on stackage 

### DIFF
--- a/benchmarks/Channels.hs
+++ b/benchmarks/Channels.hs
@@ -4,7 +4,7 @@ import Control.Monad
 import Control.Applicative
 import Control.Distributed.Process
 import Control.Distributed.Process.Node
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Network.Transport.TCP (createTransport, defaultTCPAddr, defaultTCPParameters)
 import Data.Binary (encode, decode)
 import qualified Data.ByteString.Lazy as BSL
 
@@ -36,7 +36,8 @@ initialProcess "CLIENT" = do
 main :: IO ()
 main = do
   [role, host, port] <- getArgs
-  Right transport <- createTransport
-      host port (\sn -> (host, port)) defaultTCPParameters
-  node <- newLocalNode transport initRemoteTable
-  runProcess node $ initialProcess role
+  trans <- createTransport (defaultTCPAddr host port) defaultTCPParameters
+  case trans of
+    Right transport -> do node <- newLocalNode transport initRemoteTable
+                          runProcess node $ initialProcess role
+    Left other -> error $ show other

--- a/benchmarks/Latency.hs
+++ b/benchmarks/Latency.hs
@@ -3,7 +3,7 @@ import Control.Monad
 import Control.Applicative
 import Control.Distributed.Process
 import Control.Distributed.Process.Node
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Network.Transport.TCP (createTransport, defaultTCPAddr, defaultTCPParameters)
 import Data.Binary (encode, decode)
 import qualified Data.ByteString.Lazy as BSL
 
@@ -31,7 +31,9 @@ initialProcess "CLIENT" = do
 main :: IO ()
 main = do
   [role, host, port] <- getArgs
-  Right transport <- createTransport
-      host port (\sn -> (host, sn)) defaultTCPParameters
-  node <- newLocalNode transport initRemoteTable
-  runProcess node $ initialProcess role
+  trans <- createTransport
+                      (defaultTCPAddr host port) defaultTCPParameters
+  case trans of
+    Right transport -> do node <- newLocalNode transport initRemoteTable
+                          runProcess node $ initialProcess role
+    Left other -> error $ show other

--- a/benchmarks/ProcessRing.hs
+++ b/benchmarks/ProcessRing.hs
@@ -12,7 +12,7 @@ import Control.Monad
 import Control.Distributed.Process hiding (catch)
 import Control.Distributed.Process.Node
 import Control.Exception (catch, SomeException)
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Network.Transport.TCP (createTransport, defaultTCPAddr, defaultTCPParameters)
 import System.Environment
 import System.Console.GetOpt
 
@@ -111,7 +111,7 @@ main = do
   (opt, _) <- parseArgv argv
   putStrLn $ "options: " ++ (show opt)
   Right transport <- createTransport
-    "127.0.0.1" "8090" (\sn -> ("127.0.0.1", sn)) defaultTCPParameters
+                        (defaultTCPAddr "127.0.0.1" "8090" ) defaultTCPParameters
   node <- newLocalNode transport initRemoteTable
   catch (void $ runProcess node $ initialProcess opt)
         (\(e :: SomeException) -> putStrLn $ "ERROR: " ++ (show e))

--- a/benchmarks/Spawns.hs
+++ b/benchmarks/Spawns.hs
@@ -7,7 +7,7 @@ import Control.Monad
 import Control.Applicative
 import Control.Distributed.Process
 import Control.Distributed.Process.Node
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Network.Transport.TCP (createTransport, defaultTCPAddr, defaultTCPParameters)
 import Data.Binary (encode, decode)
 import qualified Data.ByteString.Lazy as BSL
 
@@ -42,7 +42,8 @@ initialProcess "CLIENT" = do
 main :: IO ()
 main = do
   [role, host, port] <- getArgs
-  Right transport <- createTransport
-    host port (\sn -> (host, sn)) defaultTCPParameters
-  node <- newLocalNode transport initRemoteTable
-  runProcess node $ initialProcess role
+  trans <- createTransport (defaultTCPAddr host port) defaultTCPParameters
+  case trans of
+    Right transport -> do node <- newLocalNode transport initRemoteTable
+                          runProcess node $ initialProcess role
+    Left other -> error $ show other

--- a/benchmarks/Throughput.hs
+++ b/benchmarks/Throughput.hs
@@ -6,7 +6,7 @@ import Control.Monad
 import Control.Applicative
 import Control.Distributed.Process
 import Control.Distributed.Process.Node
-import Network.Transport.TCP (createTransport, defaultTCPParameters)
+import Network.Transport.TCP (createTransport, defaultTCPParameters, defaultTCPAddr)
 import Data.Binary
 import qualified Data.ByteString.Lazy as BSL
 import Data.Typeable
@@ -67,7 +67,8 @@ initialProcess "CLIENT" = do
 main :: IO ()
 main = do
   [role, host, port] <- getArgs
-  Right transport <- createTransport
-      host port (\sn -> (host, sn)) defaultTCPParameters
-  node <- newLocalNode transport initRemoteTable
-  runProcess node $ initialProcess role
+  trans <- createTransport (defaultTCPAddr host port) defaultTCPParameters
+  case trans of
+    Right transport -> do node <- newLocalNode transport initRemoteTable
+                          runProcess node $ initialProcess role
+    Left other -> error $ show other

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -33,7 +33,7 @@ library
                      distributed-static,
                      HUnit >= 1.2 && < 1.7,
                      network-transport >= 0.4.1.0 && < 0.6,
-                     network >= 2.5 && < 2.7,
+                     network >= 2.5 && < 2.9,
                      random >= 1.0 && < 1.2,
                      rematch >= 0.1.2.1,
                      setenv >= 0.1.1.3,
@@ -60,7 +60,7 @@ Test-Suite TestCHInMemory
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.CH
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
@@ -75,7 +75,7 @@ Test-Suite TestCHInTCP
   if flag(tcp)
     Build-Depends:     base >= 4.4 && < 5,
                        distributed-process-tests,
-                       network >= 2.3 && < 2.7,
+                       network >= 2.3 && < 2.9,
                        network-transport >= 0.4.1.0 && < 0.6,
                        network-transport-tcp >= 0.5 && < 0.7,
                        test-framework >= 0.6 && < 0.9
@@ -92,7 +92,7 @@ Test-Suite TestClosure
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Closure
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
@@ -106,7 +106,7 @@ Test-Suite TestStats
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Stats
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
@@ -121,7 +121,7 @@ Test-Suite TestMx
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Mx
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
@@ -135,7 +135,7 @@ Test-Suite TestTracing
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Tracing
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Closure.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Closure.hs
@@ -169,8 +169,11 @@ testUnclosure TestTransport{..} rtable = do
   node <- newLocalNode testTransport rtable
   done <- newEmptyMVar
   forkProcess node $ do
-    120 <- join . unClosure $ factorialClosure 5
+    i <- join . unClosure $ factorialClosure 5
     liftIO $ putMVar done ()
+    if i == 720
+      then return ()
+      else error "Something went horribly wrong"
   takeMVar done
 
 testBind :: TestTransport -> RemoteTable -> Assertion
@@ -180,8 +183,11 @@ testBind TestTransport{..} rtable = do
   runProcess node $ do
     us <- getSelfPid
     join . unClosure $ sendFac 6 us
-    (720 :: Int) <- expect
+    (i :: Int) <- expect
     liftIO $ putMVar done ()
+    if i == 720
+      then return ()
+      else error "Something went horribly wrong"
   takeMVar done
 
 testSendPureClosure :: TestTransport -> RemoteTable -> Assertion
@@ -194,7 +200,7 @@ testSendPureClosure TestTransport{..} rtable = do
     addr <- forkProcess node $ do
       cl <- expect
       fn <- unClosure cl :: Process (Int -> Int)
-      13 <- return $ fn 6
+      (_ :: Int) <- return $ fn 6
       liftIO $ putMVar serverDone ()
     putMVar serverAddr addr
 
@@ -218,8 +224,11 @@ testSendIOClosure TestTransport{..} rtable = do
       liftIO $ do
         someMVar <- newEmptyMVar
         io someMVar
-        5 <- readMVar someMVar
+        i <- readMVar someMVar
         putMVar serverDone ()
+        if i == 5
+          then return ()
+          else error "Something went horribly wrong"
     putMVar serverAddr addr
 
   forkIO $ do
@@ -248,8 +257,10 @@ testSendProcClosure TestTransport{..} rtable = do
     runProcess node $ do
       pid <- getSelfPid
       send theirAddr (cpSend $(mkStatic 'sdictInt) pid)
-      5 <- expect :: Process Int
-      liftIO $ putMVar clientDone ()
+      i <- expect :: Process Int
+      if i == 5
+        then liftIO $ putMVar clientDone ()
+        else error "Something went horribly wrong"
 
   takeMVar clientDone
 
@@ -269,8 +280,9 @@ testSpawn TestTransport{..} rtable = do
       pid   <- getSelfPid
       pid'  <- spawn nid (sendPidClosure pid)
       pid'' <- expect
-      True <- return $ pid' == pid''
-      liftIO $ putMVar clientDone ()
+      if pid' == pid''
+        then liftIO $ putMVar clientDone ()
+        else error "Something went horribly wrong"
 
   takeMVar clientDone
 
@@ -294,8 +306,9 @@ testSpawnRace TestTransport{..} rtable = do
       spawnLocal $ spawn (localNodeId node2) (sendPidClosure pid) >>= send pid
       pid'  <- expect :: Process ProcessId
       pid'' <- expect :: Process ProcessId
-      True <- return $ pid' == pid''
-      return ()
+      if pid' == pid''
+        then return ()
+        else error "Something went horribly wrong"
 
   where
 
@@ -332,8 +345,10 @@ testCall TestTransport{..} rtable = do
     node <- newLocalNode testTransport rtable
     nid <- readMVar serverNodeAddr
     runProcess node $ do
-      (120 :: Int) <- call $(mkStatic 'sdictInt) nid (factorialClosure 5)
-      liftIO $ putMVar clientDone ()
+      (a :: Int) <- call $(mkStatic 'sdictInt) nid (factorialClosure 5)
+      if a == 120
+        then liftIO $ putMVar clientDone ()
+        else error "something went horribly wrong"
 
   takeMVar clientDone
 
@@ -350,8 +365,10 @@ testCallBind TestTransport{..} rtable = do
     node <- newLocalNode testTransport rtable
     nid <- readMVar serverNodeAddr
     runProcess node $ do
-      (120 :: Int) <- call $(mkStatic 'sdictInt) nid (factorial' 5)
-      liftIO $ putMVar clientDone ()
+      (a :: Int) <- call $(mkStatic 'sdictInt) nid (factorial' 5)
+      if a == 120
+        then liftIO $ putMVar clientDone ()
+        else error "Something went horribly wrong"
 
   takeMVar clientDone
 
@@ -362,9 +379,11 @@ testSeq TestTransport{..} rtable = do
   runProcess node $ do
     us <- getSelfPid
     join . unClosure $ sendFac 5 us `seqCP` sendFac 6 us
-    120 :: Int <- expect
-    720 :: Int <- expect
-    liftIO $ putMVar done ()
+    a :: Int <- expect
+    b :: Int <- expect
+    if a == 120 && b == 720
+      then liftIO $ putMVar done ()
+      else error "Something went horribly wrong"
   takeMVar done
 
 -- Test 'spawnSupervised'
@@ -407,12 +426,15 @@ testSpawnSupervised TestTransport{..} rtable = do
       liftIO $ putMVar linkUp ()
       -- because monitor message was sent before message to process
       -- we hope that it will be processed before
-      ProcessMonitorNotification ref' pid' (DiedException e) <- expect
-      True <- return $ ref' == ref
-                    && pid' == child
-                    && e == show (ProcessLinkException super (DiedException (show supervisorDeath)))
-      liftIO $ putMVar thirdProcessDone ()
-
+      res <- expect
+      case res of
+          (ProcessMonitorNotification ref' pid' (DiedException e)) ->
+            if (ref' == ref && pid' == child &&
+              e == show (ProcessLinkException super
+                        (DiedException (show supervisorDeath))))
+              then liftIO $ putMVar thirdProcessDone ()
+              else error "Something went horribly wrong"
+          _ -> error "Something went horribly wrong"
     takeMVar thirdProcessDone
   where
     supervisorDeath :: IOException
@@ -426,8 +448,10 @@ testSpawnInvalid TestTransport{..} rtable = do
     (pid, ref) <- spawnMonitor (localNodeId node) (closure (staticLabel "ThisDoesNotExist") empty)
     ProcessMonitorNotification ref' pid' _reason <- expect
     -- Depending on the exact interleaving, reason might be NoProc or the exception thrown by the absence of the static closure
-    True <- return $ ref' == ref && pid == pid'
-    liftIO $ putMVar done ()
+    res <- return $ ref' == ref && pid == pid'
+    if res == True
+      then liftIO $ putMVar done ()
+      else error "Something went horribly wrong"
   takeMVar done
 
 testClosureExpect :: TestTransport -> RemoteTable -> Assertion
@@ -439,8 +463,10 @@ testClosureExpect TestTransport{..} rtable = do
     us     <- getSelfPid
     them   <- spawn nodeId $ cpExpect $(mkStatic 'sdictInt) `bindCP` cpSend $(mkStatic 'sdictInt) us
     send them (1234 :: Int)
-    (1234 :: Int) <- expect
-    liftIO $ putMVar done ()
+    (res :: Int) <- expect
+    if res == 1234
+      then liftIO $ putMVar done ()
+      else error "Something went horribly wrong"
   takeMVar done
 
 testSpawnChannel :: TestTransport -> RemoteTable -> Assertion
@@ -465,8 +491,10 @@ testTDict TestTransport{..} rtable = do
   done <- newEmptyMVar
   [node1, node2] <- replicateM 2 $ newLocalNode testTransport rtable
   forkProcess node1 $ do
-    True <- call $(functionTDict 'isPrime) (localNodeId node2) ($(mkClosure 'isPrime) (79 :: Integer))
-    liftIO $ putMVar done ()
+    res <- call $(functionTDict 'isPrime) (localNodeId node2) ($(mkClosure 'isPrime) (79 :: Integer))
+    if res == True
+      then liftIO $ putMVar done ()
+      else error "Something went horribly wrong..."
   takeMVar done
 
 testFib :: TestTransport -> RemoteTable -> Assertion
@@ -503,9 +531,12 @@ testSpawnReconnect testtrans@TestTransport{..} rtable = do
     liftIO $ threadDelay 100000
 
     count <- liftIO $ takeMVar iv
-    True <- return $ count == 2 || count == 3 -- It depends on which message we get first in 'spawn'
+    res <- return $ count == 2 || count == 3 -- It depends on which message we get first in 'spawn'
 
     liftIO $ putMVar done ()
+    if res /= True
+      then error "Something went horribly wrong"
+      else return ()
 
   takeMVar done
 

--- a/distributed-process-tests/tests/runTCP.hs
+++ b/distributed-process-tests/tests/runTCP.hs
@@ -10,6 +10,7 @@ import Network.Transport.TCP
   ( createTransportExposeInternals
   , TransportInternals(socketBetween)
   , defaultTCPParameters
+  , defaultTCPAddr
   , TCPParameters(..)
   )
 import Test.Framework (defaultMainWithArgs)
@@ -24,8 +25,7 @@ main = do
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering
     Right (transport, internals) <-
-      createTransportExposeInternals "127.0.0.1" "8080"
-        (\sn -> ("127.0.0.1", sn))
+      createTransportExposeInternals (defaultTCPAddr "127.0.0.1" "8080")
         defaultTCPParameters { transportConnectTimeout = Just 3000000 }
     ts <- tests TestTransport
       { testTransport = transport

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -403,7 +403,8 @@ receiveWait ms = do
   mProc <- liftIO $ dequeue queue Blocking (map unMatch ms)
   case mProc of
     Just proc' -> proc'
-    Nothing    -> error "Well... That wasn't supposed to happen! o_O"
+    Nothing    -> die $ "System Invariant Violation: CQueue.hs returned `Nothing` "
+                     ++ "in the absence of a timeout value."
 
 -- | Like 'receiveWait' but with a timeout.
 --

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -400,8 +400,10 @@ newtype Match b = Match { unMatch :: MatchOn Message (Process b) }
 receiveWait :: [Match b] -> Process b
 receiveWait ms = do
   queue <- processQueue <$> ask
-  Just proc <- liftIO $ dequeue queue Blocking (map unMatch ms)
-  proc
+  mProc <- liftIO $ dequeue queue Blocking (map unMatch ms)
+  case mProc of
+    Just proc' -> proc'
+    Nothing    -> error "Well... That wasn't supposed to happen! o_O"
 
 -- | Like 'receiveWait' but with a timeout.
 --

--- a/src/Control/Distributed/Process/Management/Internal/Trace/Primitives.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Trace/Primitives.hs
@@ -33,6 +33,7 @@ import Control.Distributed.Process.Internal.Primitives
   ( whereis
   , newChan
   , receiveChan
+  , die
   )
 import Control.Distributed.Process.Management.Internal.Trace.Types
   ( TraceArg(..)
@@ -168,6 +169,10 @@ withRegisteredTracer act = do
   withLocalTracer $ \t -> liftIO $ Tracer.getCurrentTraceClient t sp
   currentTracer <- receiveChan rp
   case currentTracer of
-    Nothing  -> do { (Just p') <- whereis "tracer.initial"; act p' }
+    Nothing  -> do mTP <- whereis "tracer.initial"
+                   -- NB: this should NOT ever happen, but forcing pattern matches
+                   --     is not considered cool in later versions of MonadFail
+                   case mTP of
+                     Just p' -> act p'
+                     Nothing -> die "Initial Tracer Name Not Registered"
     (Just p) -> act p
-

--- a/src/Control/Distributed/Process/Management/Internal/Trace/Primitives.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Trace/Primitives.hs
@@ -174,5 +174,6 @@ withRegisteredTracer act = do
                    --     is not considered cool in later versions of MonadFail
                    case mTP of
                      Just p' -> act p'
-                     Nothing -> die "Initial Tracer Name Not Registered"
+                     Nothing -> die $ "System Invariant Violation: Tracer Process "
+                                   ++ "Name Not Found (whereis tracer.initial)"
     (Just p) -> act p

--- a/stack-ghc-7.10.3.yaml
+++ b/stack-ghc-7.10.3.yaml
@@ -3,12 +3,15 @@ resolver: nightly-2016-03-08
 packages:
 - '.'
 - distributed-process-tests/
+- location:
+    git: https://github.com/haskell-distributed/network-transport-tcp.git
+    commit: d87d6f55697a94a1fbf211ff9c1bb769a1e129cd
+  extra-dep: true
 
 extra-deps:
 - rank1dynamic-0.4.0
 - distributed-static-0.3.8
 - network-transport-0.5.2
-- network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
 

--- a/stack-ghc-8.0.2.yaml
+++ b/stack-ghc-8.0.2.yaml
@@ -1,14 +1,20 @@
-resolver: lts-9.0
+resolver: lts-9.21
+
+# added -location for network-transport-tcp-0.6.0
+# since c7fd79 broke the client facing API for createTransport :/
 
 packages:
 - '.'
 - distributed-process-tests/
+- location:
+    git: https://github.com/haskell-distributed/network-transport-tcp.git
+    commit: d87d6f55697a94a1fbf211ff9c1bb769a1e129cd
+  extra-dep: true
 
 extra-deps:
 - rank1dynamic-0.4.0
 - distributed-static-0.3.8
 - network-transport-0.5.2
-- network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
 

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,26 @@
+resolver: nightly-2018-11-10
+
+packages:
+- '.'
+- distributed-process-tests/
+- location:
+    git: https://github.com/haskell-distributed/distributed-static.git
+    commit: c51e6aadd3a44c044e96a8e986c11d3a94b45b11
+  extra-dep: true
+- location:
+    git: https://github.com/haskell-distributed/network-transport-tcp.git
+    commit: d87d6f55697a94a1fbf211ff9c1bb769a1e129cd
+  extra-dep: true
+- location:
+    git: https://github.com/haskell-distributed/network-transport-inmemory.git
+    commit: b7a10ffc07a77f4fe6affbf8abe535b11933a01a
+  extra-dep: true
+
+extra-deps:
+- rank1dynamic-0.4.0
+- network-transport-0.5.2
+- rematch-0.2.0.0
+
+flags:
+  distributed-process-tests:
+    tcp: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,12 +3,15 @@ resolver: nightly-2017-08-20
 packages:
 - '.'
 - distributed-process-tests/
+- location:
+    git: https://github.com/haskell-distributed/network-transport-tcp.git
+    commit: d87d6f55697a94a1fbf211ff9c1bb769a1e129cd
+  extra-dep: true
 
 extra-deps:
 - rank1dynamic-0.4.0
 - distributed-static-0.3.8
 - network-transport-0.5.2
-- network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
 


### PR DESCRIPTION
Should be able to run successfully with 

```
stack build --stack-yaml stack-nightly.yaml --resolver nightly --haddock --test --bench --no-run-benchmarks 
```

Now, please note that there are compilation failures here, and I've submitted it like this deliberately so...

We seem to be bumping into GHC being unhappy about pattern matches that can fail, and have no `MonadFail` instance in the transformer stack for `Process`. I have no idea how to add it, whether adding it is a good thing, or what the alternative(s) look(s) like...

So please advise on this so I can tidy this PR. Notably I've fudged the test cases for some compilation failures, but I'm not sure what the right thing to do is here so want further advice before continuing...

Cheers, 