### PR TITLE
Improvements to build and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ matrix:
   - env: ARGS="--stack-yaml stack-ghc-8.0.2.yaml"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: ARGS="--stack-yaml stack-ghc-8.2.2.yaml"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: ARGS="--stack-yaml stack-ghc-8.4.4.yaml"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   - env: ARGS=
     addons: {apt: {packages: [libgmp-dev]}}
 

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -31,6 +31,7 @@ library
                      bytestring >= 0.9 && < 0.12,
                      distributed-process >= 0.6.0 && < 0.8,
                      distributed-static,
+                     exceptions >= 0.5,
                      HUnit >= 1.2 && < 1.7,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network >= 2.5 && < 2.7,
@@ -126,7 +127,7 @@ Test-Suite TestMx
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
-  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  ghc-options:       -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests
 
 Test-Suite TestTracing
@@ -140,5 +141,5 @@ Test-Suite TestTracing
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
-  ghc-options:       -Wall -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  ghc-options:       -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Closure.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Closure.hs
@@ -486,7 +486,7 @@ testSpawnReconnect :: TestTransport -> RemoteTable -> Assertion
 testSpawnReconnect testtrans@TestTransport{..} rtable = do
   [node1, node2] <- replicateM 2 $ newLocalNode testTransport rtable
   let nid1 = localNodeId node1
-      nid2 = localNodeId node2
+      -- nid2 = localNodeId node2
   done <- newEmptyMVar
   iv <- newMVar (0 :: Int)
 

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
@@ -4,7 +4,6 @@ module Control.Distributed.Process.Tests.Mx (tests) where
 import Control.Distributed.Process.Tests.Internal.Utils
 import Network.Transport.Test (TestTransport(..))
 
-import Control.Concurrent (threadDelay)
 import Control.Distributed.Process
 import Control.Distributed.Process.Node
 import Control.Distributed.Process.Management
@@ -21,7 +20,6 @@ import Control.Distributed.Process.Management
   , mxUpdateLocal
   , mxNotify
   , mxBroadcast
-  , mxGetId
   )
 import Control.Monad (void)
 import Data.Binary

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Receive.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Receive.hs
@@ -10,13 +10,12 @@ import Network.Transport.Test (TestTransport(..))
 
 import Network.Transport (Transport)
 import Control.Distributed.Process
-import Control.Distributed.Process.Closure
 import Control.Distributed.Process.Node
 
 import Control.Monad
 
 import Test.HUnit (Assertion, (@?=))
-import Test.Framework (Test, defaultMain)
+import Test.Framework (Test)
 import Test.Framework.Providers.HUnit (testCase)
 
 -- Tests:
@@ -43,7 +42,7 @@ recTest2 :: ReceivePort ()
          -> SendPort String
          -> ReceivePort String -> ReceivePort String
          -> Process ()
-recTest2 wait sync r1 r2 = do
+recTest2 wait sync r1 _ = do
   forever $ do
     receiveChan wait
     r <- receiveWait
@@ -56,7 +55,7 @@ recTest3 :: ReceivePort ()
          -> SendPort String
          -> ReceivePort String -> ReceivePort String
          -> Process ()
-recTest3 wait sync r1 r2 = do
+recTest3 wait sync r1 _ = do
   forever $ do
     receiveChan wait
     r <- receiveWait
@@ -69,7 +68,7 @@ recTest4 :: ReceivePort ()
          -> SendPort String
          -> ReceivePort String -> ReceivePort String
          -> Process ()
-recTest4 wait sync r1 r2 = do
+recTest4 wait sync r1 _ = do
   forever $ do
     receiveChan wait
     r <- receiveWait
@@ -83,11 +82,11 @@ master :: Process ()
 master = do
   (waits,waitr) <- newChan
   (syncs,syncr) <- newChan
-  let go expect = do
+  let go expected = do
          sendChan waits ()
          r <- receiveChan syncr
-         liftIO $ print (r,expect, r == expect)
-         liftIO $ r @?= expect
+         liftIO $ print (r, expected, r == expected)
+         liftIO $ r @?= expected
 
   liftIO $ putStrLn "---- Test 1 ----"
   (s1,r1) <- newChan

--- a/distributed-process-tests/tests/runInMemory.hs
+++ b/distributed-process-tests/tests/runInMemory.hs
@@ -8,7 +8,6 @@ import Network.Transport.Test (TestTransport(..))
 import Network.Transport.InMemory
 import Test.Framework (defaultMainWithArgs)
 
-import Control.Concurrent (threadDelay)
 import System.Environment (getArgs)
 
 main :: IO ()

--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -21,7 +21,7 @@ Description:   This is an implementation of Cloud Haskell, as described in
 
                You will probably also want to install a Cloud Haskell backend such
                as distributed-process-simplelocalnet.
-Tested-With:   GHC==7.6.3 GHC==7.8.4 GHC==7.10.3 GHC==8.0.1
+Tested-With:   GHC==7.10.3 GHC==8.0.2 GHC==8.2.2 GHC==8.4.4
 Category:      Control
 extra-source-files: ChangeLog
 

--- a/stack-ghc-8.0.2.yaml
+++ b/stack-ghc-8.0.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.0
+resolver: lts-9.21
 
 packages:
 - '.'
@@ -11,6 +11,7 @@ extra-deps:
 - network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
+# - exceptions-0.8.2.1 # test dependency
 
 flags:
   distributed-process-tests:

--- a/stack-ghc-8.2.2.yaml
+++ b/stack-ghc-8.2.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-03-08
+resolver: lts-11.22
 
 packages:
 - '.'
@@ -11,7 +11,7 @@ extra-deps:
 - network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
-- exceptions-0.8.2.1 # test dependency
+# - exceptions-0.8.2.1 # test dependency
 
 flags:
   distributed-process-tests:

--- a/stack-ghc-8.4.4.yaml
+++ b/stack-ghc-8.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-03-08
+resolver: lts-12.17
 
 packages:
 - '.'
@@ -11,7 +11,6 @@ extra-deps:
 - network-transport-tcp-0.6.0
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
-- exceptions-0.8.2.1 # test dependency
 
 flags:
   distributed-process-tests:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,7 @@
 resolver: nightly-2017-08-20
 
+# TODO: we can enable nightly-2018-11-11 once PR #319 is merged
+
 packages:
 - '.'
 - distributed-process-tests/


### PR DESCRIPTION
This set of patches should

* reduce compilation warnings
* remove use of deprecated APIs in our test suites
* make travis test the last four major GHC versions
* declare the tested GHC versions correctly in the cabal file 