### PR TITLE
Prevent registered names from leaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,11 @@ script:
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInTCP
 - stack ${ARGS} test $ARG='--plain -t "!SpawnReconnect"' ${TEST_PACKAGE}TestClosure
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestStats
-- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMx
-- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracing
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInMemory
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInTCP
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInMemory
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInTCP
+
+notifications:
+  slack:
+    secure: LbqbNjK1KiHNiQo/i/Za4vkMD9l9mhmN+PWYFBQkNvGFWffSRayRKFrTqt4znV2p7h4dY1XZFoC7T5RemBVQLq2ppZAUWxkITeu1OUlnmVLDfJLeVYGTR/fn90nP6Y5ITE7T3A07nKmWaRbKpIgFBAOjzgqaM0csscDx3z0WW18=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
   include:
   - env: ARGS="--stack-yaml stack-ghc-7.10.3.yaml"
     addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: ARGS="--stack-yaml stack-ghc-8.0.2.yaml"
+  - env: ARGS="--stack-yaml stack-ghc-8.2.2.yaml"
     addons: {apt: {packages: [libgmp-dev]}}
-
-  - env: ARGS=
+  - env: ARGS="--stack-yaml stack-ghc-8.4.4.yaml"
+    addons: {apt: {packages: [libgmp-dev]}}
+  - env: ARGS="--stack-yaml stack-nightly.yaml --resolver nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ script:
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInMemory
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInTCP
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInMemory
-- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInTCP
 
 notifications:
   slack:

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -120,7 +120,7 @@ Test-Suite TestMxInMemory
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Mx
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9
@@ -134,7 +134,7 @@ Test-Suite TestTracingInMemory
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Tracing
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
-                     network >= 2.3 && < 2.7,
+                     network >= 2.3 && < 2.9,
                      network-transport >= 0.4.1.0 && < 0.6,
                      network-transport-inmemory >= 0.5,
                      test-framework >= 0.6 && < 0.9

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -155,17 +155,3 @@ Test-Suite TestMxInTCP
   Extensions:        CPP
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests
-
-Test-Suite TestTracingInTCP
-  Type:              exitcode-stdio-1.0
-  Main-Is:           runInMemory.hs
-  CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Tracing
-  Build-Depends:     base >= 4.4 && < 5,
-                     distributed-process-tests,
-                     network >= 2.3 && < 2.9,
-                     network-transport >= 0.4.1.0 && < 0.6,
-                     network-transport-inmemory >= 0.5,
-                     test-framework >= 0.6 && < 0.9
-  Extensions:        CPP
-  ghc-options:       -Wall -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
-  HS-Source-Dirs:    tests

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -114,8 +114,7 @@ Test-Suite TestStats
   ghc-options:       -Wall -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests
 
-
-Test-Suite TestMx
+Test-Suite TestMxInMemory
   Type:              exitcode-stdio-1.0
   Main-Is:           runInMemory.hs
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Mx
@@ -129,7 +128,35 @@ Test-Suite TestMx
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests
 
-Test-Suite TestTracing
+Test-Suite TestTracingInMemory
+  Type:              exitcode-stdio-1.0
+  Main-Is:           runInMemory.hs
+  CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Tracing
+  Build-Depends:     base >= 4.4 && < 5,
+                     distributed-process-tests,
+                     network >= 2.3 && < 2.7,
+                     network-transport >= 0.4.1.0 && < 0.6,
+                     network-transport-inmemory >= 0.5,
+                     test-framework >= 0.6 && < 0.9
+  Extensions:        CPP
+  ghc-options:       -Wall -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  HS-Source-Dirs:    tests
+
+Test-Suite TestMxInTCP
+  Type:              exitcode-stdio-1.0
+  Main-Is:           runInMemory.hs
+  CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Mx
+  Build-Depends:     base >= 4.4 && < 5,
+                     distributed-process-tests,
+                     network >= 2.3 && < 2.7,
+                     network-transport >= 0.4.1.0 && < 0.6,
+                     network-transport-inmemory >= 0.5,
+                     test-framework >= 0.6 && < 0.9
+  Extensions:        CPP
+  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
+  HS-Source-Dirs:    tests
+
+Test-Suite TestTracingInTCP
   Type:              exitcode-stdio-1.0
   Main-Is:           runInMemory.hs
   CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.Tracing

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
@@ -1505,7 +1505,7 @@ testRegistryMonitoring TestTransport{..} = do
     -- away, and thus not be subjected to a 20 second delay. The value of 4
     -- seconds appears to work optimally on osx and across several linux distros
     -- running in virtual machines (which is essentially what we do in CI)
-    receiveTimeout 4000000 [ matchAny return ]
+    void $ receiveTimeout 4000000 [ matchAny return ]
 
   -- This delay doesn't serve much purpose in the happy path, however if some
   -- future patch breaks the cooperative behaviour of node controllers viz

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
@@ -1416,7 +1416,6 @@ testRegistryMonitoring TestTransport{..} = do
   -- Many labels. Test if all labels associated with process
   -- are removed from registry when it dies.
   remote2 <- testRemote remoteNode
-  remoteX <- testRemote remoteNode
   runProcess localNode $
     let waitpoll = do
         w1 <- whereis "test-3" :: Process (Maybe ProcessId)
@@ -1424,11 +1423,8 @@ testRegistryMonitoring TestTransport{..} = do
         forM_ (w1 <|> w2) (const waitpoll)
     in do register "test-3" remote2
           register "test-4" remote2
-          register "test-X" remoteX
           send remote2 ()
           waitpoll
-          rX <- whereis "test-X"
-          rX `shouldBe` (equalTo (Just remoteX))
           return ()
 
 {- XXX: waiting including patch for nsend for remote process

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
@@ -1506,7 +1506,6 @@ testRegistryMonitoring TestTransport{..} = do
     -- seconds appears to work optimally on osx and across several linux distros
     -- running in virtual machines (which is essentially what we do in CI)
     receiveTimeout 4000000 [ matchAny return ]
-    return ()
 
   -- This delay doesn't serve much purpose in the happy path, however if some
   -- future patch breaks the cooperative behaviour of node controllers viz

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
@@ -176,14 +176,14 @@ testAgentEventHandling result = do
 
   stash result $ seenAlive && seenDead
 
-testMxMonitorEvents :: Process ()
-testMxMonitorEvents = do
+testMxRegEvents :: Process ()
+testMxRegEvents = do
 
   {- This test only deals with the local case, to ensure that we are being
      notified in the expected order - the remote cases related to the
      behaviour of the node controller are contained in the CH test suite. -}
 
-  let label = "testMxMonitorEvents"
+  let label = "testMxRegEvents"
   let agentLabel = "listener-agent"
   let delay = 1000000
   (regChan, regSink) <- newChan
@@ -223,9 +223,65 @@ testMxMonitorEvents = do
 
   mapM_ (flip kill $ "test-complete") [agent, p1, p2]
 
+testMxRegMon :: LocalNode -> Process ()
+testMxRegMon remoteNode = do
+
+  -- ensure that when a registered process dies, we get a notification that
+  -- it has been unregistered as well as seeing the name get removed
+
+  let label1 = "aaaaa"
+  let label2 = "bbbbb"
+  let isValid l = l ==label1 || l == label2
+  let agentLabel = "listener-agent"
+  let delay = 1000000
+  (regChan, regSink) <- newChan
+  (unRegChan, unRegSink) <- newChan
+  agent <- mxAgent (MxAgentId agentLabel) () [
+      mxSink $ \ev -> do
+        case ev of
+          MxRegistered pid label
+            | isValid label -> liftMX $ sendChan regChan (label, pid)
+          MxUnRegistered pid label
+            | isValid label -> liftMX $ sendChan unRegChan (label, pid)
+          _                 -> return ()
+        mxReady
+    ]
+
+  (sp, rp) <- newChan
+  liftIO $ forkProcess remoteNode $ do
+    getSelfPid >>= sendChan sp
+    expect :: Process ()
+
+  p1 <- receiveChan rp
+
+  register label1 p1
+  reg1 <- receiveChanTimeout delay regSink
+  reg1 `shouldBe` equalTo (Just (label1, p1))
+
+  register label2 p1
+  reg2 <- receiveChanTimeout delay regSink
+  reg2 `shouldBe` equalTo (Just (label2, p1))
+
+  n1 <- whereis label1
+  n1 `shouldBe` equalTo (Just p1)
+
+  n2 <- whereis label2
+  n2 `shouldBe` equalTo (Just p1)
+
+  kill p1 "goodbye"
+
+  unreg1 <- receiveChanTimeout delay unRegSink
+  unreg2 <- receiveChanTimeout delay unRegSink
+
+  sort [unreg1, unreg2]
+    `shouldBe` equalTo [Just (label1, p1), Just (label2, p1)]
+
+  kill agent "test-complete"
+
 tests :: TestTransport -> IO [Test]
 tests TestTransport{..} = do
   node1 <- newLocalNode testTransport initRemoteTable
+  node2 <- newLocalNode testTransport initRemoteTable
   return [
       testGroup "Mx Agents" [
           testCase "Event Handling"
@@ -252,7 +308,9 @@ tests TestTransport{..} = do
                             "fifth"]) testAgentPrioritisation)
       ]
     , testGroup "Mx Events" [
-        testCase "Monitor Events"
-          (runProcess node1 testMxMonitorEvents)
+        testCase "Name Registration Events"
+          (runProcess node1 testMxRegEvents)
+      , testCase "Post Death Name UnRegistration Events"
+          (runProcess node1 (testMxRegMon node2))
       ]
     ]

--- a/src/Control/Distributed/Process/Internal/Primitives.hs
+++ b/src/Control/Distributed/Process/Internal/Primitives.hs
@@ -76,6 +76,7 @@ module Control.Distributed.Process.Internal.Primitives
   , unlink
   , monitor
   , unmonitor
+  , unmonitorAsync
   , withMonitor
   , withMonitor_
     -- * Logging

--- a/src/Control/Distributed/Process/Management/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Types.hs
@@ -30,6 +30,7 @@ import qualified Control.Monad.State as ST
   ( MonadState
   , StateT
   )
+import Control.Monad.Fix (MonadFix)
 import Data.Binary
 import Data.Typeable (Typeable)
 import GHC.Generics
@@ -112,6 +113,7 @@ newtype MxAgent s a =
   } deriving ( Functor
              , Monad
              , MonadIO
+             , MonadFix
              , ST.MonadState (MxAgentState s)
              , Typeable
              , Applicative

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -1129,7 +1129,7 @@ ncEffectGetInfo from pid =
   case mProc of
     Nothing   -> dispatch (isLocal node (ProcessIdentifier from))
                           from (ProcessInfoNone DiedUnknownId)
-    Just proc    -> do
+    Just proc -> do
       itsLinks    <- Set.map fst . BiMultiMap.lookupBy1st them <$>
                        gets (^. links)
       itsMons     <- BiMultiMap.lookupBy1st them <$> gets (^. monitors)
@@ -1143,8 +1143,8 @@ ncEffectGetInfo from pid =
                    infoNode               = (processNodeId pid)
                  , infoRegisteredNames    = reg
                  , infoMessageQueueLength = size
-                 , infoMonitors       = Set.toList itsMons
-                 , infoLinks          = Set.toList itsLinks
+                 , infoMonitors           = Set.toList itsMons
+                 , infoLinks              = Set.toList itsLinks
                  }
   where dispatch :: (Serializable a)
                  => Bool

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -955,7 +955,11 @@ ncEffectRegister from label atnode mPid reregistration = do
                do modify' $ registeredHereFor label ^= mPid
                   updateRemote node currentVal mPid
                   case mPid of
-                    (Just p) -> liftIO $ trace node (MxRegistered p label)
+                    (Just p) -> do
+                      if reregistration
+                        then liftIO $ trace node (MxUnRegistered (fromJust currentVal) label)
+                        else return ()
+                      liftIO $ trace node (MxRegistered p label)
                     Nothing  -> liftIO $ trace node (MxUnRegistered (fromJust currentVal) label)
              newVal <- gets (^. registeredHereFor label)
              ncSendToProcess from $ unsafeCreateUnencodedMessage $

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -376,6 +376,7 @@ startServiceProcesses node = do
     -- loops during tracing if the user reregisters the "logger" with a custom
     -- process which uses 'send' or other primitives which are traced.
     register "trace.logger" logger
+    void $ registryMonitorAgent
  where
    loop = do
      receiveWait

--- a/src/Control/Distributed/Process/Node.hs
+++ b/src/Control/Distributed/Process/Node.hs
@@ -31,7 +31,6 @@ import qualified Data.Map as Map
   , delete
   , toList
   , fromList
-  , filter
   , insert
   , lookup
   , partition
@@ -193,7 +192,6 @@ import Control.Distributed.Process.Management
   , liftMX
   , mxUpdateLocal
   , mxGetLocal
-  , mxSetLocal
   , mxReady
   , MxEvent(..)
   , MxAgentId(..)
@@ -325,9 +323,6 @@ startDefaultTracer node' = do
 
 -- TODO: we need a better mechanism for defining and registering services
 
-registryMonitorAgentId :: MxAgentId
-registryMonitorAgentId = MxAgentId "service.registry.monitoring"
-
 {- note [registry monitoring agent]
    This agent listens for 'MxRegistered' and 'MxUnRegistered' events and tracks
    all labels for remote 'ProcessId's that are stored in the registry.
@@ -362,6 +357,9 @@ registryMonitorAgent = do
       -- The framework simply discards any input you don't have a handler for.
       -- See Management.hs `runAgent` for details.
     ]
+  where
+    registryMonitorAgentId :: MxAgentId
+    registryMonitorAgentId = MxAgentId "service.registry.monitoring"
 
 -- | Start and register the service processes on a node
 startServiceProcesses :: LocalNode -> IO ()

--- a/stack-ghc-8.2.2.yaml
+++ b/stack-ghc-8.2.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.18 # Use GHC 8.4.4
+resolver: lts-11.22
 
 packages:
 - '.'

--- a/stack-ghc-8.4.4.yaml
+++ b/stack-ghc-8.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.18 # Use GHC 8.4.4
+resolver: lts-12.18
 
 packages:
 - '.'

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-11-10
+resolver: nightly
 
 packages:
 - '.'
@@ -9,11 +9,11 @@ packages:
   extra-dep: true
 - location:
     git: https://github.com/haskell-distributed/network-transport-tcp.git
-    commit: d87d6f55697a94a1fbf211ff9c1bb769a1e129cd
+    commit: d58250e2388b86a1865ac4139373cbdc106e72e1
   extra-dep: true
 - location:
     git: https://github.com/haskell-distributed/network-transport-inmemory.git
-    commit: b7a10ffc07a77f4fe6affbf8abe535b11933a01a
+    commit: 0ce97924f15a8c1570b2355151834305c9bd2a28
   extra-dep: true
 
 extra-deps:


### PR DESCRIPTION
This patch subsumes #184, and incorporates #321 (which I have submitted separately, since it's less contentious). 

I have taken the code @qnikst wrote for #184, but refactored it to use the label tracking approach suggested by @mboes, which is not only simpler, but the Map handling code in the tweag:DP-100 branch is incorrect. I have also kept the agent code inside of the Node.hs module, as suggested elsewhere in the review for that PR.

This patch also incorporates the [tests](https://github.com/haskell-distributed/distributed-process-tests/pull/15) written by @qnikst (before the repos were reorganised), and I've included some additional tests in the Mx.hs test suite, which verifies that the ordering constraints are observed.

Although I have not managed to close out #241 yet, there is no reason to believe that the management event bus does not hold to the following assertion (made in the comments for that issue/ticket):

> messages dispatched on an STM broadcast channel (i.e., management event bus) are guaranteed to be delivered with the same FIFO ordering guarantees that exist between two communicating processes, such that communication from the node controller threads (i.e., MxEvent's) will never be re-ordered, but messages dispatched to the event bus by other processes (including, but not limited to agents) are only guaranteed to be ordered between one sender and one receiver.