### PR TITLE
Fix tracing/management publication of MxSent events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-sudo: false
+sudo: required
 
 matrix:
   include:

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Internal/Utils.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Internal/Utils.hs
@@ -91,6 +91,7 @@ import Test.HUnit (Assertion, assertFailure)
 import Test.HUnit.Base (assertBool)
 
 import GHC.Generics
+import System.Timeout (timeout)
 
 -- | A mutable cell containing a test result.
 type TestResult a = MVar a
@@ -233,7 +234,8 @@ testProcessReport pid = do
 tryRunProcess :: LocalNode -> Process () -> IO ()
 tryRunProcess node p = do
   tid <- liftIO myThreadId
-  runProcess node $ catch p (\e -> liftIO $ throwTo tid (e::SomeException))
+  void $ timeout (1000000 * 60 * 5 :: Int) $
+    runProcess node $ catch p (\e -> liftIO $ throwTo tid (e::SomeException))
 
 tryForkProcess :: LocalNode -> Process () -> IO ProcessId
 tryForkProcess node p = do

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Internal/Utils.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Internal/Utils.hs
@@ -74,12 +74,13 @@ import Control.Concurrent
 import Control.Concurrent.MVar
   ( putMVar
   )
-import Control.Distributed.Process
+import Control.Distributed.Process hiding (finally, catch)
 import Control.Distributed.Process.Node
 import Control.Distributed.Process.Serializable()
 
 import Control.Exception (AsyncException(ThreadKilled), SomeException)
 import Control.Monad (forever, void)
+import Control.Monad.Catch (finally, catch)
 import Control.Monad.STM (atomically)
 import Control.Rematch hiding (match)
 import Control.Rematch.Run

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
@@ -489,7 +489,7 @@ tests TestTransport{..} = do
           (delayedAssertion
            "expected process deaths to result in unregistration events"
            node1 () (testMxRegMon node2))
-      , testGroup "SendEvents" $ buildTestCases node1 node2
+      -- , testGroup "SendEvents" $ buildTestCases node1 node2
       ]
     ]
   where

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/Mx.hs
@@ -489,7 +489,7 @@ tests TestTransport{..} = do
           (delayedAssertion
            "expected process deaths to result in unregistration events"
            node1 () (testMxRegMon node2))
-      -- , testGroup "SendEvents" $ buildTestCases node1 node2
+      , testGroup "SendEvents" $ buildTestCases node1 node2
       ]
     ]
   where

--- a/src/Control/Distributed/Process/Management/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Types.hs
@@ -56,6 +56,8 @@ data MxEvent =
     -- ^ fired whenever a node /dies/ (i.e., the connection is broken/disconnected)
   | MxSent             ProcessId    ProcessId Message
     -- ^ fired whenever a message is sent from a local process
+  | MxSentToName       String       ProcessId Message
+    -- ^ fired whenever a named send occurs
   | MxReceived         ProcessId    Message
     -- ^ fired whenever a message is received by a local process
   | MxConnected        ConnectionId EndPointAddress

--- a/src/Control/Distributed/Process/Management/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Management/Internal/Types.hs
@@ -21,6 +21,7 @@ import Control.Concurrent.STM
 import Control.Distributed.Process.Internal.Types
   ( Process
   , ProcessId
+  , SendPortId
   , Message
   , DiedReason
   , NodeId
@@ -59,8 +60,12 @@ data MxEvent =
     -- ^ fired whenever a message is sent from a local process
   | MxSentToName       String       ProcessId Message
     -- ^ fired whenever a named send occurs
+  | MxSentToPort       ProcessId    SendPortId Message
+    -- ^ fired whenever a sendChan occurs
   | MxReceived         ProcessId    Message
     -- ^ fired whenever a message is received by a local process
+  | MxReceivedPort     SendPortId   Message
+    -- ^ fired whenever a message is received via a typed channel
   | MxConnected        ConnectionId EndPointAddress
     -- ^ fired when a network-transport connection is first established
   | MxDisconnected     ConnectionId EndPointAddress

--- a/stack-ghc-7.10.3.yaml
+++ b/stack-ghc-7.10.3.yaml
@@ -14,7 +14,7 @@ extra-deps:
 - network-transport-0.5.2
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
-- exceptions-0.8.2.1
+- exceptions-0.8.2.1 # test dependency
 
 flags:
   distributed-process-tests:

--- a/stack-ghc-7.10.3.yaml
+++ b/stack-ghc-7.10.3.yaml
@@ -14,7 +14,7 @@ extra-deps:
 - network-transport-0.5.2
 - network-transport-inmemory-0.5.2
 - rematch-0.2.0.0
-- exceptions-0.8.2.1 # test dependency
+- exceptions-0.8.2.1
 
 flags:
   distributed-process-tests:


### PR DESCRIPTION
Fixes #265, and adds support for tracing messages sent to typed channels.