### PR TITLE
RFC on this approach - NB: this pull request is incomplete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,16 @@ before_install:
   stack --version
 
 install:
+- export TEST_PACKAGE="distributed-process-tests:"
 - stack $ARGS setup --no-terminal;
-  stack $ARGS build --no-terminal --only-snapshot --test --no-run-tests;
+  stack $ARGS build --no-terminal --only-snapshot --test --no-run-tests --flag ${TEST_PACKAGE}remote;
 
 script:
 - export ARG='--test-arguments'
   export TEST_PACKAGE="distributed-process-tests:"
+  export DISTRIBUTED_PROCESS_TEST_NODE="1"
+- stack $ARGS build --no-terminal ${TEST_PACKAGE}RemoteHost
+- stack $ARGS run --no-terminal ${TEST_PACKAGE}RemoteHost &
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInMemory
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInTCP
 - stack ${ARGS} test $ARG='--plain -t "!SpawnReconnect"' ${TEST_PACKAGE}TestClosure
@@ -37,6 +41,7 @@ script:
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInMemory
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInTCP
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInMemory
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestRemoteNodesTCP
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ script:
 - export ARG='--test-arguments'
   export TEST_PACKAGE="distributed-process-tests:"
   export DISTRIBUTED_PROCESS_TEST_NODE="1"
-- stack $ARGS build --no-terminal ${TEST_PACKAGE}RemoteHost --flag ${TEST_PACKAGE}remote;
-- stack $ARGS run --no-terminal ${TEST_PACKAGE}RemoteHost &
+- stack $ARGS build --no-terminal ${TEST_PACKAGE}RemoteHost --flag ${TEST_PACKAGE}remote
+- stack $ARGS run --no-terminal ${TEST_PACKAGE}RemoteHost --flag ${TEST_PACKAGE}remote &
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInMemory
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInTCP
 - stack ${ARGS} test $ARG='--plain -t "!SpawnReconnect"' ${TEST_PACKAGE}TestClosure
@@ -41,7 +41,7 @@ script:
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInMemory
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInTCP
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInMemory
-- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestRemoteNodesTCP --flag ${TEST_PACKAGE}remote 
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestRemoteNodesTCP --flag ${TEST_PACKAGE}remote
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 - export ARG='--test-arguments'
   export TEST_PACKAGE="distributed-process-tests:"
   export DISTRIBUTED_PROCESS_TEST_NODE="1"
-- stack $ARGS build --no-terminal ${TEST_PACKAGE}RemoteHost
+- stack $ARGS build --no-terminal ${TEST_PACKAGE}RemoteHost --flag ${TEST_PACKAGE}remote;
 - stack $ARGS run --no-terminal ${TEST_PACKAGE}RemoteHost &
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInMemory
 - stack ${ARGS} test $ARG='--plain -t "!Flaky"' ${TEST_PACKAGE}TestCHInTCP
@@ -41,7 +41,7 @@ script:
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInMemory
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestMxInTCP
 - stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestTracingInMemory
-- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestRemoteNodesTCP
+- stack ${ARGS} test $ARG='--plain' ${TEST_PACKAGE}TestRemoteNodesTCP --flag ${TEST_PACKAGE}remote 
 
 notifications:
   slack:

--- a/distributed-process-tests/distributed-process-tests.cabal
+++ b/distributed-process-tests/distributed-process-tests.cabal
@@ -16,6 +16,10 @@ flag tcp
   Description: build and run TCP tests
   Default:     False
 
+flag remote
+  description: Build Remote Node executable(s) and TestRemoteNodesTCP test suite
+  default: False
+
 library
   exposed-modules:   Network.Transport.Test
                      Control.Distributed.Process.Tests.CH
@@ -24,10 +28,12 @@ library
                      Control.Distributed.Process.Tests.Receive
                      Control.Distributed.Process.Tests.Stats
                      Control.Distributed.Process.Tests.Tracing
+                     Control.Distributed.Process.Tests.RemoteNodes
                      Control.Distributed.Process.Tests.Internal.Utils
   Build-Depends:     base >= 4.4 && < 5,
                      ansi-terminal >= 0.5,
                      binary >= 0.5 && < 0.9,
+                     rank1dynamic,
                      bytestring >= 0.9 && < 0.12,
                      distributed-process >= 0.6.0 && < 0.8,
                      distributed-static,
@@ -156,3 +162,34 @@ Test-Suite TestMxInTCP
   Extensions:        CPP
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
   HS-Source-Dirs:    tests
+
+Test-Suite TestRemoteNodesTCP
+  Type:              exitcode-stdio-1.0
+  Main-Is:           runTCPMultiNode.hs
+  CPP-Options:       -DTEST_SUITE_MODULE=Control.Distributed.Process.Tests.RemoteNodes
+  if flag(remote)
+    Build-Depends:     base >= 4.4 && < 5,
+                       exceptions,
+                       rank1dynamic,
+                       distributed-process,
+                       distributed-process-tests,
+                       network >= 2.3 && < 2.9,
+                       network-transport >= 0.4.1.0 && < 0.6,
+                       network-transport-tcp >= 0.5 && < 0.7,
+                       test-framework >= 0.6 && < 0.9
+  else
+    Buildable:       False
+  Extensions:        CPP
+  ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N
+  HS-Source-Dirs:    tests
+
+executable RemoteHost
+  Build-Depends:   base >= 4.6 && < 5,
+                   rank1dynamic,
+                   distributed-process,
+                   distributed-process-tests,
+                   network-transport-tcp >= 0.3 && < 0.7,
+                   bytestring >= 0.9 && < 0.11,
+                   binary >= 0.6.3 && < 0.10
+  Main-Is:         tests/RemoteHost.hs
+  ghc-options:     -Wall -threaded -O2 -rtsopts -with-rtsopts=-N

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
@@ -1818,7 +1818,8 @@ tests testtrans = return [
       , testCase "MaskRestoreScope"    (testMaskRestoreScope    testtrans)
       , testCase "ExitLocal"           (testExitLocal           testtrans)
       , testCase "ExitRemote"          (testExitRemote          testtrans)
-      , testCase "RegistryMonitoring"  (testRegistryMonitoring  testtrans)
+      -- NB: migrated to runTCPMultiNode
+      -- , testCase "RegistryMonitoring"  (testRegistryMonitoring  testtrans)
       , testCase "TextCallLocal"       (testCallLocal           testtrans)
       -- Unsafe Primitives
       , testCase "TestUnsafeSend"      (testUnsafeSend          testtrans)

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/CH.hs
@@ -1556,22 +1556,20 @@ testRegistryMonitoring :: TestTransport -> Assertion
 testRegistryMonitoring TestTransport{..} = do
   node1 <- newLocalNode testTransport initRemoteTable
   node2 <- newLocalNode testTransport initRemoteTable
-  waitH <- newEmptyMVar
 
   let nid = localNodeId node2
   pid <- forkProcess node1 $ do
     self <- getSelfPid
     runUntilRegistered nid self
     say $ regName ++ " registered to " ++ show self
-    liftIO $ takeMVar waitH
+    expect :: Process ()
 
   runProcess node2 $ do
     register regName pid
     res <- whereis regName
-    us <- getSelfPid
-    liftIO $ do
-      putMVar waitH ()
-      assertBool "expected (Just pid)" $ res == (Just pid)
+    liftIO $ assertBool "expected (Just pid)" $ res == (Just pid)
+
+    send pid ()
 
     -- This delay isn't essential!
     -- The test case passes perfectly fine without it (feel free to comment out

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/RemoteNodes.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/RemoteNodes.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE StaticPointers #-}
+
+module Control.Distributed.Process.Tests.RemoteNodes (tests, remoteTable) where
+
+#if ! MIN_VERSION_base(4,6,0)
+import Prelude hiding (catch)
+#endif
+
+import Test.Framework (defaultMainWithArgs)
+import System.Environment (getArgs)
+import System.IO
+import Control.Distributed.Process
+import Control.Distributed.Process.Node
+import Control.Distributed.Process.Tests.Internal.Utils (shouldBe, pause)
+import Control.Distributed.Static (registerStatic, staticClosure, staticLabel)
+import Control.Monad (void)
+import Data.Rank1Dynamic (toDynamic)
+import Data.Maybe (isNothing, isJust)
+import Test.HUnit (Assertion, assertBool)
+import Test.Framework (Test)
+import Test.Framework.Providers.HUnit (testCase)
+-- import Control.Rematch hiding (match, isNothing, isJust)
+-- import Control.Rematch.Run (Match(..))
+
+--------------------------------------------------------------------------------
+-- The tests proper                                                           --
+--------------------------------------------------------------------------------
+
+awaitsRegistration :: Process ()
+awaitsRegistration = do
+  self <- getSelfPid
+  nid <- expect :: Process NodeId
+  runUntilRegistered nid self
+  say $ regName ++ " registered to " ++ show self
+  expect :: Process ()
+  where
+    runUntilRegistered nid us = do
+      whereisRemoteAsync nid regName
+      receiveWait [
+          matchIf (\(WhereIsReply n (Just p)) -> n == regName && p == us)
+                  (const $ return ())
+        ]
+
+regName :: String
+regName = "testRegisterRemote"
+
+awaitsRegClosure :: Closure (Process ())
+awaitsRegClosure = staticClosure (staticLabel "$awaitsRegistration")
+
+remoteTable :: RemoteTable -> RemoteTable
+remoteTable =
+  registerStatic "$awaitsRegistration" $ toDynamic awaitsRegistration
+
+{-
+-- | Given a name and a 'Process ()' value, generate a 'Closure (Process ())'
+-- value and a function to add the closure to a remote table.
+mkProcBaseClosure
+  :: [Char]
+  -> Process ()
+  -> (Closure (Process ()), RemoteTable -> RemoteTable)
+mkProcBaseClosure name p = (procClosure, registerProc p)
+  where
+    procClosure = staticClosure (staticLabel name)
+    registerProc = registerStatic name . toDynamic
+    -}
+
+testRegistryMonitoring :: LocalNode -> NodeId -> Assertion
+testRegistryMonitoring node nid =
+  runProcess node $ do
+    pid <- spawn nid awaitsRegClosure
+    liftIO $ putStrLn $ "spawned " ++ show pid
+    register regName pid
+    res <- whereis regName
+    liftIO $ assertBool ("expected Just pid but was " ++ show res) $ res == Just pid
+
+    send pid nid
+
+    -- This delay isn't essential!
+    -- The test case passes perfectly fine without it (feel free to comment out
+    -- and see), however waiting a few seconds here, makes it much more likely
+    -- that in delayUntilMaybeUnregistered we will hit the match case right
+    -- away, and thus not be subjected to a 20 second delay. The value of 4
+    -- seconds appears to work optimally on osx and across several linux distros
+    -- running in virtual machines (which is essentially what we do in CI)
+    void $ receiveTimeout 4000000 [ matchAny return ]
+
+    -- this message should cause the remote process to exit normally
+    send pid ()
+
+    -- This delay doesn't serve much purpose in the happy path, however if some
+    -- future patch breaks the cooperative behaviour of node controllers viz
+    -- remote process registration and notification taking place via ncEffectDied,
+    -- there would be the possibility of a race in the test case should we attempt
+    -- to evaluate `whereis regName` on node2 right away. In case the name is still
+    -- erroneously registered, observing the 20 second delay (or lack of), could at
+    -- least give a hint that something is wrong, and we give up our time slice
+    -- so that there's a higher change the registrations have been cleaned up
+    -- in either case.
+    delayUntilMaybeUnregistered nid pid
+
+    res <- whereis regName
+    case res of
+      Nothing  -> return ()
+      Just pid -> liftIO $ assertBool ("expected Nothing, but got " ++ show pid) False
+
+  where
+    delayUntilMaybeUnregistered nid p = do
+      whereisRemoteAsync nid regName
+      receiveTimeout 20000000 {- 20 sec delay -} [
+          matchIf (\(WhereIsReply n p) -> n == regName && isNothing p)
+                  (const $ return ())
+        ]
+      return ()
+
+tests :: LocalNode -> NodeId -> IO [Test]
+tests node nid = return [
+      testCase "RegistryMonitoring" (testRegistryMonitoring node nid)
+    ]

--- a/distributed-process-tests/src/Control/Distributed/Process/Tests/RemoteNodes.hs
+++ b/distributed-process-tests/src/Control/Distributed/Process/Tests/RemoteNodes.hs
@@ -51,19 +51,6 @@ remoteTable :: RemoteTable -> RemoteTable
 remoteTable =
   registerStatic "$awaitsRegistration" $ toDynamic awaitsRegistration
 
-{-
--- | Given a name and a 'Process ()' value, generate a 'Closure (Process ())'
--- value and a function to add the closure to a remote table.
-mkProcBaseClosure
-  :: [Char]
-  -> Process ()
-  -> (Closure (Process ()), RemoteTable -> RemoteTable)
-mkProcBaseClosure name p = (procClosure, registerProc p)
-  where
-    procClosure = staticClosure (staticLabel name)
-    registerProc = registerStatic name . toDynamic
-    -}
-
 testRegistryMonitoring :: LocalNode -> NodeId -> Assertion
 testRegistryMonitoring node nid =
   runProcess node $ do

--- a/distributed-process-tests/tests/RemoteHost.hs
+++ b/distributed-process-tests/tests/RemoteHost.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Control.Monad
+import Control.Distributed.Process hiding (catch)
+import Control.Distributed.Process.Node
+-- NB: we import the test suite module here, so we can take advantage of static
+-- pointers to simplify the test suite considerably..
+import Control.Distributed.Process.Tests.RemoteNodes hiding (remoteTable)
+import qualified Control.Distributed.Process.Tests.RemoteNodes as R (remoteTable)
+import Control.Exception (catch, SomeException)
+import Network.Transport.TCP
+  ( createTransport
+  , defaultTCPParameters
+  , defaultTCPAddr
+  , TCPParameters(..)
+  )
+
+initialProcess :: Process ()
+initialProcess = do
+  self <- getSelfPid
+  register "distributed-process-tests" self
+  receiveWait [ matchIf (== self) (const $ return ()) ]
+
+main :: IO ()
+main = do
+  nt <- createTransport (defaultTCPAddr "127.0.0.1" "10516" )
+                        (defaultTCPParameters { tcpNoDelay = True })
+  case nt of
+    Right transport -> do node <- newLocalNode transport $ R.remoteTable initRemoteTable
+                          catch (void $ runProcess node initialProcess)
+                                (\(e :: SomeException) -> putStrLn $ "ERROR: " ++ show e)
+    _               -> error "Unable to initialise network-transport"

--- a/distributed-process-tests/tests/RemoteHost.hs
+++ b/distributed-process-tests/tests/RemoteHost.hs
@@ -29,4 +29,4 @@ main = do
     Right transport -> do node <- newLocalNode transport $ R.remoteTable initRemoteTable
                           catch (void $ runProcess node initialProcess)
                                 (\(e :: SomeException) -> putStrLn $ "ERROR: " ++ show e)
-    _               -> error "Unable to initialise network-transport"
+    Left  badness   -> error $ "Unable to initialise network-transport " ++ show badness

--- a/distributed-process-tests/tests/runTCPMultiNode.hs
+++ b/distributed-process-tests/tests/runTCPMultiNode.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import TEST_SUITE_MODULE (tests)
+import qualified TEST_SUITE_MODULE as Remote (remoteTable)
+import Control.Distributed.Process (NodeId(..))
+import Control.Distributed.Process.Node (initRemoteTable, newLocalNode)
+import Control.Monad (unless)
+import Control.Monad.Catch (throwM)
+import Network.Transport (EndPointAddress(..))
+import Network.Transport.TCP
+  ( createTransport
+  , defaultTCPParameters
+  , defaultTCPAddr
+  , TCPParameters(..)
+  )
+import Test.Framework (defaultMainWithArgs)
+import System.Environment (lookupEnv, getArgs)
+import System.Exit (ExitCode(ExitSuccess))
+import System.IO
+{-
+import System.Process.Typed (shell, runProcess, withProcess_, ProcessConfig)
+
+buildTestNodePConfig :: ProcessConfig () () ()
+buildTestNodePConfig = "stack build distributed-process-tests:RemoteHost"
+
+runTestNodePConfig :: ProcessConfig () () ()
+runTestNodePConfig = "stack run distributed-process-tests:RemoteHost"
+
+spawnTestNode :: IO ()
+spawnTestNode = do
+  err <- runProcess buildTestNodePConfig
+  unless (err == ExitSuccess) $ error "Unable to build RemoteHost"
+  withProcess_ runTestNodePConfig $ const runTestsWithNodePresent
+
+-}
+
+spawnTestNode :: IO ()
+spawnTestNode = error "Unsupported Configuration"
+
+runTestsWithNodePresent :: IO ()
+runTestsWithNodePresent = do
+  nt <- createTransport (defaultTCPAddr "127.0.0.1" "10517")
+                        (defaultTCPParameters { tcpNoDelay = True })
+  let remoteId = NodeId $ EndPointAddress "127.0.0.1:10516:0"
+  case nt of
+    Right transport -> do node  <- newLocalNode transport $ Remote.remoteTable initRemoteTable
+                          args  <- getArgs
+                          suite <- tests node remoteId
+                          defaultMainWithArgs suite args
+    _               -> error "Unable to initialise network-transport"
+
+main :: IO ()
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
+  env <- lookupEnv "DISTRIBUTED_PROCESS_TEST_NODE"
+  -- ctx <- lookupEnv "DISTRIBUTED_PROCESS_SPAWN_NODE"
+  case env of
+    Nothing -> putStrLn errorNoNode >> error errorNoNode
+    Just _  -> runTestsWithNodePresent
+    -- (Nothing, Just _)  -> spawnTestNode
+  where
+    errorNoNode = "NO TEST NODE PRESENT"


### PR DESCRIPTION
I _think_ the approach outlined in this patch set is a reasonable solution for #333. I would envisage moving a few of the more racy/flaky test cases over to this approach. I'd like some feedback on the general advisability if possible, before moving a few other test cases and merging.

It would be worth seeing if my argument in #333 about the scheduler creating the failure conditions for our test case, holds up to scrutiny. 

I would prefer if this were ultimately in some kind of integration-test package, executed on a build pipeline once the regular test suites are complete. Sadly travis doesn't really have a proper notion of pipelines (frankly, apart from Jenkins/Hudson and Bamboo, I've seen for CI systems that offer a strong build pipeline capability, and none for free)...

And before someone says it, I *absolutely* think we should start doing model based testing in addition to this approach. I've been looking at https://github.com/advancedtelematic/quickcheck-state-machine-distributed, and considering some other options.

Anyway... Does this patch make sense, and do you agree with my thoughts in #333? Because if you think I'm barking up the wrong tree, then this is a pointless additional of technical debt, and complicates the CI build quite a bit. 