### PR TITLE
Fixed compilation error on GHC 9.0.2

### DIFF
--- a/.github/workflows/distributed-process-ci.yml
+++ b/.github/workflows/distributed-process-ci.yml
@@ -6,12 +6,12 @@ jobs:
     strategy:
       matrix:
         ghcVersion:
-          [ "7.10.3"
-          , "8.2.2"
+          [ "8.2.2"
           , "8.4.4"
           , "8.6.5"
           , "8.8.4"
           , "8.10.7"
+          , "9.0.2"
           ]
     container: "fpco/stack-build-small"
     steps:

--- a/.github/workflows/distributed-process-ci.yml
+++ b/.github/workflows/distributed-process-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/stack-root
-          key: cache-key-${{ runner.os }}-${{ hashFiles(format('stack-ghc-{{0}}.yaml', matrix.ghcVersion)) }}
+          key: cache-key-${{ runner.os }}-${{ hashFiles(format('stack-ghc-{0}.yaml', matrix.ghcVersion)) }}
       - shell: bash
         name: run tests
         run: |

--- a/.github/workflows/distributed-process-ci.yml
+++ b/.github/workflows/distributed-process-ci.yml
@@ -1,5 +1,5 @@
 name: distributed-process-ci
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/Control/Distributed/Process/Internal/Closure/TH.hs
+++ b/src/Control/Distributed/Process/Internal/Closure/TH.hs
@@ -183,7 +183,7 @@ generateDefs (origName, fullType) = do
                                            _                    -> ([], fullType)
 
     -- The main "static" entry
-    (static, register) <- makeStatic typVars typ' --M_TODO
+    (static, register) <- makeStatic typVars typ'
 
     -- If n :: T1 -> T2, static serializable dictionary for T1
     -- TODO: we should check if arg is an instance of Serializable, but we cannot

--- a/src/Control/Distributed/Process/Internal/Closure/TH.hs
+++ b/src/Control/Distributed/Process/Internal/Closure/TH.hs
@@ -28,6 +28,9 @@ import Language.Haskell.TH
   , Exp
   , Type(AppT, ForallT, VarT, ArrowT)
   , Info(VarI)
+#if MIN_VERSION_template_haskell(2,17,0)
+  , Specificity
+#endif
   , TyVarBndr(PlainTV, KindedTV)
   , Pred
 #if MIN_VERSION_template_haskell(2,10,0)
@@ -180,7 +183,7 @@ generateDefs (origName, fullType) = do
                                            _                    -> ([], fullType)
 
     -- The main "static" entry
-    (static, register) <- makeStatic typVars typ'
+    (static, register) <- makeStatic typVars typ' --M_TODO
 
     -- If n :: T1 -> T2, static serializable dictionary for T1
     -- TODO: we should check if arg is an instance of Serializable, but we cannot
@@ -203,7 +206,11 @@ generateDefs (origName, fullType) = do
            , concat [register, registerSDict, registerTDict]
            )
   where
+#if MIN_VERSION_template_haskell(2,17,0)
+    makeStatic :: [TyVarBndr Specificity] -> Type -> Q ([Dec], [Q Exp])
+#else
     makeStatic :: [TyVarBndr] -> Type -> Q ([Dec], [Q Exp])
+#endif
     makeStatic typVars typ = do
       static <- generateStatic origName typVars typ
       let dyn = case typVars of
@@ -222,7 +229,12 @@ generateDefs (origName, fullType) = do
              )
 
 -- | Turn a polymorphic type into a monomorphic type using ANY and co
+#if MIN_VERSION_template_haskell(2,17,0)
+monomorphize :: [TyVarBndr Specificity] -> Type -> Q Type
+#else
 monomorphize :: [TyVarBndr] -> Type -> Q Type
+#endif
+
 monomorphize tvs =
     let subst = zip (map tyVarBndrName tvs) anys
     in everywhereM (mkM (applySubst subst))
@@ -247,7 +259,11 @@ monomorphize tvs =
     applySubst s t = gmapM (mkM (applySubst s)) t
 
 -- | Generate a static value
+#if MIN_VERSION_template_haskell(2,17,0)
+generateStatic :: Name -> [TyVarBndr Specificity] -> Type -> Q [Dec]
+#else
 generateStatic :: Name -> [TyVarBndr] -> Type -> Q [Dec]
+#endif
 generateStatic n xs typ = do
     staticTyp <- [t| Static |]
     sequence
@@ -259,7 +275,11 @@ generateStatic n xs typ = do
       , sfnD (staticName n) [| staticLabel $(showFQN n) |]
       ]
   where
+#if MIN_VERSION_template_haskell(2,17,0)
+    typeable :: TyVarBndr Specificity -> Q Pred
+#else
     typeable :: TyVarBndr -> Q Pred
+#endif
     typeable tv =
 #if MIN_VERSION_template_haskell(2,10,0)
       conT (mkName "Typeable") `appT` varT (tyVarBndrName tv)
@@ -315,9 +335,16 @@ sfnD :: Name -> Q Exp -> Q Dec
 sfnD n e = funD n [clause [] (normalB e) []]
 
 -- | The name of a type variable binding occurrence
+#if MIN_VERSION_template_haskell(2,17,0)
+tyVarBndrName :: TyVarBndr Specificity -> Name
+tyVarBndrName (PlainTV n _)    = n
+tyVarBndrName (KindedTV n _ _) = n
+#else
 tyVarBndrName :: TyVarBndr -> Name
 tyVarBndrName (PlainTV n)    = n
 tyVarBndrName (KindedTV n _) = n
+#endif
+
 
 -- | Fully qualified name; that is, the name and the _current_ module
 --

--- a/stack-ghc-9.0.2.yaml
+++ b/stack-ghc-9.0.2.yaml
@@ -1,0 +1,17 @@
+resolver: lts-19.28 # Use GHC 8.10.7
+
+packages:
+  - .
+  - distributed-process-tests/
+
+extra-deps:
+- distributed-static-0.3.9
+- rematch-0.2.0.0
+- network-transport-tcp-0.8.0
+# This version has its containers dependency bumped
+- git: https://github.com/haskell-distributed/network-transport-inmemory.git
+  commit: 0ce97924f15a8c1570b2355151834305c9bd2a28
+
+flags:
+  distributed-process-tests:
+    tcp: true

--- a/stack-ghc-9.0.2.yaml
+++ b/stack-ghc-9.0.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.28 # Use GHC 8.10.7
+resolver: lts-19.28 # Use GHC 9.0.2
 
 packages:
   - .

--- a/stack-ghc-9.2.4.yaml
+++ b/stack-ghc-9.2.4.yaml
@@ -1,0 +1,21 @@
+resolver: nightly-2022-10-11
+allow-newer: true
+
+packages:
+  - .
+  - distributed-process-tests/
+
+extra-deps:
+# Need to clone network-transport-tcp package and patch the file:
+#  src/Network/Transport/TCP/Internal.hs
+# Change import of Data.ByteString.Lazy.Builder to Data.ByteString.Builder
+- lib/network-transport-tcp
+- distributed-static-0.3.9
+- rematch-0.2.0.0
+# This version has its containers dependency bumped
+- git: https://github.com/haskell-distributed/network-transport-inmemory.git
+  commit: 0ce97924f15a8c1570b2355151834305c9bd2a28
+
+flags:
+  distributed-process-tests:
+    tcp: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc-8.10.7.yaml
+stack-ghc-9.0.2.yaml


### PR DESCRIPTION
I've corrected the Template Haskell code to account for the new behavior of TyVarBndr (with CPP macros, so it should be backwards-compatible). distributed-process now builds with the latest LTS version of stack.

All unit tests have passed locally.