### PR TITLE
Add nix-shell and hie.yaml for development purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
+dist-newstyle/
 .cabal-sandbox
 cabal.sandbox.config
 .stack*
+stack.yaml.lock

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1687793116,
+        "narHash": "sha256-6xRgZ2E9r/BNam87vMkHJ/0EPTTKzeNwhw3abKilEE4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9e4e0807d2142d17f463b26a8b796b3fe20a3011",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,27 @@
         "type": "github"
       }
     },
+    "rank1dynamic-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661536488,
+        "narHash": "sha256-SmDhpAA97NPTF7WiYKUQNNeCpR4yO9iQrtflJXiTu8c=",
+        "owner": "haskell-distributed",
+        "repo": "rank1dynamic",
+        "rev": "53c5453121592453177370daa06f098cb014c0d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell-distributed",
+        "repo": "rank1dynamic",
+        "rev": "53c5453121592453177370daa06f098cb014c0d3",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rank1dynamic-src": "rank1dynamic-src"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       compilerVersion = "ghc945";
       pkgs = nixpkgs.legacyPackages.${system};
       hsPkgs = pkgs.haskell.packages.${compilerVersion}.override {
-        overrides = hfinal: hprev: with pkgs.haskell.lib; {
+        overrides = hfinal: hprev: {
           # Internal Packages
           distributed-process = hfinal.callCabal2nix "distributed-process" ./. {};
 
@@ -38,9 +38,6 @@
     });
   in {
     formatter = forAllSystems ({pkgs, ...}: pkgs.alejandra);
-
-    # You can't build the servicehub package as a check because of IFD in cabal2nix
-    checks = {};
 
     # nix develop
     devShells = forAllSystems ({hsPkgs, pkgs, ...}: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = ''
+  This is an implementation of Cloud Haskell, as described in
+  /Towards Haskell in the Cloud/ by Jeff Epstein, Andrew Black,
+  and Simon Peyton Jones
+  (<http://research.microsoft.com/en-us/um/people/simonpj/papers/parallel/>),
+  although some of the details are different. The precise message
+  passing semantics are based on /A unified semantics for future Erlang/
+  by Hans Svensson, Lars-&#xc5;ke Fredlund and Clara Benac Earle.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSystems = function: nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (system: function rec {
+      inherit system;
+      compilerVersion = "ghc945";
+      pkgs = nixpkgs.legacyPackages.${system};
+      hsPkgs = pkgs.haskell.packages.${compilerVersion}.override {
+        overrides = hfinal: hprev: with pkgs.haskell.lib; {
+          # Internal Packages
+          distributed-process = hfinal.callCabal2nix "distributed-process" ./. {};
+
+          # External Packages
+          rank1dynamic = dontCheck (markUnbroken (hprev.rank1dynamic));
+        };
+      };
+    });
+  in {
+    formatter = forAllSystems ({pkgs, ...}: pkgs.alejandra);
+
+    # You can't build the servicehub package as a check because of IFD in cabal2nix
+    checks = {};
+
+    # nix develop
+    devShells = forAllSystems ({hsPkgs, pkgs, ...}: {
+      default = hsPkgs.shellFor {
+        name = "distributed-process";
+        packages = p: [
+          p.distributed-process
+        ];
+        buildInputs = with pkgs;
+          [
+            hsPkgs.haskell-language-server
+            hsPkgs.cabal-install
+            cabal2nix
+            haskellPackages.ghcid
+          ];
+      };
+    });
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,16 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    rank1dynamic-src = {
+      flake = false;
+      url = "github:haskell-distributed/rank1dynamic/53c5453121592453177370daa06f098cb014c0d3";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
+    rank1dynamic-src
   }: let
     forAllSystems = function: nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (system: function rec {
       inherit system;
@@ -27,7 +32,7 @@
           distributed-process = hfinal.callCabal2nix "distributed-process" ./. {};
 
           # External Packages
-          rank1dynamic = dontCheck (markUnbroken (hprev.rank1dynamic));
+          rank1dynamic = hfinal.callCabal2nix "rank1dynamic" rank1dynamic-src {};
         };
       };
     });

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,12 @@
+cradle:
+  cabal:
+    - path: "./src"
+      component: "lib:distributed-process"
+    - path: "./benchmark/Latency.hs"
+      component: "bench:distributed-process-latency"
+    - path: "./benchmark/Channels.hs"
+      component: "bench:distributed-process-channels"
+    - path: "./benchmark/Spawns.hs"
+      component: "bench:distributed-process-spawns"
+    - path: "./benchmark/ProcessRing.hs"
+      component: "bench:distributed-process-ring"


### PR DESCRIPTION
The nix shell doesn't affect any of the cabal / stack files so I hope it isn't too intrusive. I am happy to maintain it, although it shouldn't require much maintenance. The nix shell also provides HLS, so I included an `hie.yaml` file for multi-cradle support.