### PR TITLE
Update upper bound on `hashable`

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -43,7 +43,7 @@ flag old-locale
 Library
   Build-Depends:     base >= 4.9 && < 5,
                      binary >= 0.6.3 && < 0.10,
-                     hashable >= 1.2.0.5 && <= 1.4.2.0,
+                     hashable >= 1.2.0.5 && <= 1.4.3.0,
                      network-transport >= 0.4.1.0 && < 0.6,
                      stm >= 2.4 && < 2.6,
                      transformers >= 0.2 && < 0.6,


### PR DESCRIPTION
Hello,

This is a simple pull request to update the upper bound on `hashable` to include 1.4.3.0, which allows to build `distributed-process` with GHC 9.8

Cheers,
Laurent