### PR TITLE
Allow transformers-0.6.*

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -46,7 +46,7 @@ Library
                      hashable >= 1.2.0.5 && <= 1.4.3.0,
                      network-transport >= 0.4.1.0 && < 0.6,
                      stm >= 2.4 && < 2.6,
-                     transformers >= 0.2 && < 0.6,
+                     transformers >= 0.2 && < 0.7,
                      mtl >= 2.0 && < 2.4,
                      data-accessor >= 0.2 && < 0.3,
                      bytestring >= 0.9 && <= 0.12,


### PR DESCRIPTION
It's me again, this time to bump the upper bound on `transformers`.

Thanks!