### PR TITLE
Update paper URL in cabal description

### DIFF
--- a/distributed-process.cabal
+++ b/distributed-process.cabal
@@ -14,7 +14,7 @@ Synopsis:      Cloud Haskell: Erlang-style concurrency in Haskell
 Description:   This is an implementation of Cloud Haskell, as described in
                /Towards Haskell in the Cloud/ by Jeff Epstein, Andrew Black,
                and Simon Peyton Jones
-               (<http://research.microsoft.com/en-us/um/people/simonpj/papers/parallel/>),
+               (<https://simon.peytonjones.org/haskell-cloud/>),
                although some of the details are different. The precise message
                passing semantics are based on /A unified semantics for future Erlang/
                by Hans Svensson, Lars-&#xc5;ke Fredlund and Clara Benac Earle.


### PR DESCRIPTION
The previous link is dead.