### PR TITLE
Remove rematch dependency

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -45,6 +45,7 @@ jobs:
       run: |
         cabal configure --enable-tests --test-show-details=direct
         cabal freeze --minimize-conflict-set
+        cat cabal.project.freeze
     
     - name: Cache cabal work
       uses: actions/cache@v4

--- a/packages/distributed-process-async/CHANGELOG.md
+++ b/packages/distributed-process-async/CHANGELOG.md
@@ -1,3 +1,7 @@
+2024-10-30 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.2.9
+
+* Removed dependency on `rematch` (#459)
+
 2024-09-03 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.2.8
 
 * Bumped dependency bounds to support GHC 8.10.7 - GHC 9.10.1

--- a/packages/distributed-process-async/distributed-process-async.cabal
+++ b/packages/distributed-process-async/distributed-process-async.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           distributed-process-async
-version:        0.2.8
+version:        0.2.9
 build-type:     Simple
 license:        BSD-3-Clause
 license-file:   LICENCE
@@ -68,7 +68,7 @@ test-suite AsyncTests
                    ansi-terminal >= 0.5 && < 0.9,
                    distributed-process,
                    distributed-process-async,
-                   distributed-process-systest >= 0.2.0,
+                   distributed-process-systest ^>= 0.4,
                    exceptions >= 0.10 && < 1.0,
                    network >= 2.5 && < 3.3,
                    network-transport >= 0.4 && < 0.6,

--- a/packages/distributed-process-async/distributed-process-async.cabal
+++ b/packages/distributed-process-async/distributed-process-async.cabal
@@ -79,7 +79,6 @@ test-suite AsyncTests
                    stm >= 2.3 && < 2.6,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
-                   rematch >= 0.2.0.0,
                    transformers
   hs-source-dirs:
                    tests

--- a/packages/distributed-process-client-server/CHANGELOG.md
+++ b/packages/distributed-process-client-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+2024-10-30 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.2.7.0
+
+* Removed dependency on `rematch` (#459)
+
 2024-09-03 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.2.6.0
 
 * Bumped dependency bounds to support GHC 8.10.7 - GHC 9.10.1

--- a/packages/distributed-process-client-server/distributed-process-client-server.cabal
+++ b/packages/distributed-process-client-server/distributed-process-client-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           distributed-process-client-server
-version:        0.2.6.0
+version:        0.2.7.0
 build-type:     Simple
 license:        BSD-3-Clause
 license-file:   LICENCE
@@ -79,7 +79,7 @@ test-suite ManagedProcessTests
                    distributed-process-extras,
                    distributed-process-async,
                    distributed-process-client-server,
-                   distributed-process-systest >= 0.1.1,
+                   distributed-process-systest ^>= 0.4,
                    network-transport >= 0.4 && < 0.7,
                    mtl,
                    fingertree,
@@ -117,7 +117,7 @@ test-suite PrioritisedProcessTests
                    distributed-process-extras,
                    distributed-process-async,
                    distributed-process-client-server,
-                   distributed-process-systest >= 0.1.1,
+                   distributed-process-systest ^>= 0.4,
                    network-transport,
                    mtl,
                    fingertree,

--- a/packages/distributed-process-client-server/distributed-process-client-server.cabal
+++ b/packages/distributed-process-client-server/distributed-process-client-server.cabal
@@ -92,7 +92,6 @@ test-suite ManagedProcessTests
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
                    transformers,
-                   rematch >= 0.2.0.0,
                    ghc-prim,
                    exceptions
   other-modules:   Counter,
@@ -131,7 +130,6 @@ test-suite PrioritisedProcessTests
                    test-framework,
                    test-framework-hunit,
                    transformers,
-                   rematch,
                    ghc-prim,
                    exceptions
   other-modules:   ManagedProcessCommon,

--- a/packages/distributed-process-client-server/tests/TestManagedProcess.hs
+++ b/packages/distributed-process-client-server/tests/TestManagedProcess.hs
@@ -20,6 +20,7 @@ import Control.Distributed.Process.ManagedProcess
 import Control.Distributed.Process.SysTest.Utils
 import Control.Distributed.Process.Extras.Time
 import Control.Distributed.Process.Serializable()
+import Control.Monad (replicateM_)
 
 import MathsDemo
 import Counter
@@ -197,7 +198,7 @@ testCounterExceedsLimit result = do
   mref <- monitor pid
 
   -- exceed the limit
-  9 `times` (void $ incCount pid)
+  9 `replicateM_` (void $ incCount pid)
 
   -- this time we should fail
   _ <- (incCount pid)

--- a/packages/distributed-process-execution/ChangeLog
+++ b/packages/distributed-process-execution/ChangeLog
@@ -1,3 +1,7 @@
+2024-10-30 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.1.4.0
+
+* Removed dependency on `rematch` (#459)
+
 2024-09-03 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.1.3.0
 
 * Bumped dependency bounds to support GHC 8.10.7 - GHC 9.10.1

--- a/packages/distributed-process-execution/distributed-process-execution.cabal
+++ b/packages/distributed-process-execution/distributed-process-execution.cabal
@@ -98,7 +98,6 @@ test-suite ExchangeTests
                    QuickCheck >= 2.4,
                    test-framework-quickcheck2,
                    transformers,
-                   rematch >= 0.2.0.0,
                    ghc-prim
   hs-source-dirs:
                    tests
@@ -139,7 +138,6 @@ test-suite MailboxTests
                    QuickCheck >= 2.4,
                    test-framework-quickcheck2,
                    transformers,
-                   rematch >= 0.2.0.0,
                    ghc-prim
   hs-source-dirs:
                    tests

--- a/packages/distributed-process-execution/distributed-process-execution.cabal
+++ b/packages/distributed-process-execution/distributed-process-execution.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           distributed-process-execution
-version:        0.1.3.0
+version:        0.1.4.0
 build-type:     Simple
 license:        BSD-3-Clause
 license-file:   LICENCE
@@ -79,7 +79,7 @@ test-suite ExchangeTests
                    distributed-process,
                    distributed-process-execution,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.1 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    distributed-static,
                    bytestring,
                    data-accessor,
@@ -119,7 +119,7 @@ test-suite MailboxTests
                    distributed-process,
                    distributed-process-execution,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.1 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    distributed-static,
                    bytestring,
                    data-accessor,

--- a/packages/distributed-process-execution/tests/TestMailbox.hs
+++ b/packages/distributed-process-execution/tests/TestMailbox.hs
@@ -13,15 +13,13 @@ import Control.Distributed.Process.Extras.Time
 import Control.Distributed.Process.Extras.Timer
 import Control.Distributed.Process.SysTest.Utils
 
-
-import Control.Rematch (equalTo)
-
 import Prelude hiding (drop)
 
 import Data.Maybe (catMaybes)
 
 import Test.Framework as TF (defaultMain, testGroup, Test)
 import Test.Framework.Providers.HUnit
+import Test.HUnit (assertEqual)
 
 import qualified MailboxTestFilters (__remoteTable)
 import MailboxTestFilters (myFilter, intFilter)
@@ -77,9 +75,10 @@ bufferLimiting buffT result = do
   MailboxStats{ pendingMessages = pending'
               , droppedMessages = dropped'
               , currentLimit    = limit' } <- statistics mbox
-  pending' `shouldBe` equalTo 4
-  dropped' `shouldBe` equalTo 3
-  limit'   `shouldBe` equalTo 4
+  liftIO $ do
+    assertEqual mempty 4 pending'
+    assertEqual mempty 3 dropped'
+    assertEqual mempty 4 limit'  
 
   active mbox acceptEverything
   Just Delivery{ messages = recvd

--- a/packages/distributed-process-extras/ChangeLog
+++ b/packages/distributed-process-extras/ChangeLog
@@ -1,3 +1,7 @@
+2024-10-30 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.3.7
+
+* Removed dependency on `rematch` (#459)
+
 2024-09-03 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.3.6
 
 * Bumped dependency bounds to support GHC 8.10.7 - GHC 9.10.1

--- a/packages/distributed-process-extras/distributed-process-extras.cabal
+++ b/packages/distributed-process-extras/distributed-process-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           distributed-process-extras
-version:        0.3.6
+version:        0.3.7
 build-type:     Simple
 license:        BSD-3-Clause
 license-file:   LICENCE
@@ -75,7 +75,7 @@ test-suite InternalQueueTests
                    ansi-terminal >= 0.5 && < 0.9,
                    distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    HUnit >= 1.2 && < 2,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
@@ -97,7 +97,7 @@ test-suite PrimitivesTests
                    ansi-terminal >= 0.5 && < 0.9,
                    distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    network-transport >= 0.4 && < 0.6,
                    mtl,
                    containers,
@@ -125,7 +125,7 @@ test-suite TimerTests
                    deepseq,
                    distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    network-transport >= 0.4 && < 0.6,
                    network-transport-tcp >= 0.4 && < 0.9,
                    HUnit >= 1.2 && < 2,
@@ -152,7 +152,7 @@ test-suite LoggerTests
                    unordered-containers >= 0.2.3.0 && < 0.3,
                    distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.4,
+                   distributed-process-systest ^>= 0.4,
                    distributed-static,
                    bytestring,
                    data-accessor,

--- a/packages/distributed-process-extras/distributed-process-extras.cabal
+++ b/packages/distributed-process-extras/distributed-process-extras.cabal
@@ -81,7 +81,6 @@ test-suite InternalQueueTests
                    test-framework-hunit,
                    QuickCheck >= 2.4,
                    test-framework-quickcheck2,
-                   rematch >= 0.2.0.0,
                    ghc-prim
   hs-source-dirs:  tests
   ghc-options:     -rtsopts
@@ -110,7 +109,6 @@ test-suite PrimitivesTests
                    stm,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
-                   rematch >= 0.2.0.0,
                    transformers
   hs-source-dirs:  tests
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -135,7 +133,6 @@ test-suite TimerTests
                    test-framework-hunit,
                    QuickCheck >= 2.4,
                    test-framework-quickcheck2,
-                   rematch >= 0.2.0.0,
                    ghc-prim
   hs-source-dirs:  tests
   ghc-options:     -rtsopts
@@ -172,7 +169,6 @@ test-suite LoggerTests
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
                    transformers,
-                   rematch >= 0.2.0.0,
                    ghc-prim
   hs-source-dirs:  tests
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind

--- a/packages/distributed-process-extras/tests/TestLog.hs
+++ b/packages/distributed-process-extras/tests/TestLog.hs
@@ -4,7 +4,6 @@
 
 module Main where
 
--- import Control.Exception (SomeException)
 import Control.Concurrent.MVar (MVar, newMVar, takeMVar, putMVar, newEmptyMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TChan
@@ -12,7 +11,7 @@ import Control.Distributed.Process hiding (monitor)
 import Control.Distributed.Process.Closure (remotable, mkStaticClosure)
 import Control.Distributed.Process.Node
 import Control.Distributed.Process.Extras hiding (__remoteTable)
-import qualified Control.Distributed.Process.Extras.SystemLog as Log (Logger, error)
+import qualified Control.Distributed.Process.Extras.SystemLog as Log (Logger)
 import Control.Distributed.Process.Extras.SystemLog hiding (Logger, error)
 import Control.Distributed.Process.SysTest.Utils
 import Control.Distributed.Process.Extras.Time
@@ -31,7 +30,6 @@ import GHC.Read
 import Text.ParserCombinators.ReadP as P
 import Text.ParserCombinators.ReadPrec
 
-import qualified Network.Transport as NT
 
 logLevelFormatter :: Message -> Process (Maybe String)
 logLevelFormatter m = handleMessage m showLevel

--- a/packages/distributed-process-extras/tests/TestPrimitives.hs
+++ b/packages/distributed-process-extras/tests/TestPrimitives.hs
@@ -16,11 +16,9 @@ import Control.Distributed.Process.Extras.Call
 import Control.Distributed.Process.Extras.Monitoring
 import Control.Distributed.Process.Extras.Time
 import Control.Monad (void)
-import Control.Rematch hiding (match)
-import qualified Network.Transport as NT (Transport)
 import Network.Transport.TCP()
 
-import Test.HUnit (Assertion)
+import Test.HUnit (Assertion, assertEqual, assertBool)
 import Test.Framework (Test, testGroup, defaultMain)
 import Test.Framework.Providers.HUnit (testCase)
 import Network.Transport.TCP
@@ -113,8 +111,9 @@ testMonitorNodeDeath transport result = do
     mn1 <- liftIO $ takeMVar nid2
     mn2 <- liftIO $ takeMVar nid3
 
-    [mn1, mn2] `shouldContain` n1
-    [mn1, mn2] `shouldContain` n2
+    liftIO $ do
+      assertBool mempty $ n1 `elem` [mn1, mn2]
+      assertBool mempty $ n2 `elem` [mn1, mn2]
 
     nid4 <- liftIO $ newEmptyMVar
     node4 <- liftIO $ newLocalNode transport initRemoteTable
@@ -125,7 +124,7 @@ testMonitorNodeDeath transport result = do
 
     mn3 <- liftIO $ takeMVar nid4
     NodeUp n3 <- expect
-    mn3 `shouldBe` (equalTo n3)
+    liftIO $ assertEqual mempty n3 mn3
 
     liftIO $ closeLocalNode node4
     stash result ()

--- a/packages/distributed-process-extras/tests/TestQueues.hs
+++ b/packages/distributed-process-extras/tests/TestQueues.hs
@@ -1,26 +1,20 @@
 {-# LANGUAGE PatternGuards  #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Main where
 
 import qualified Control.Distributed.Process.Extras.Internal.Queue.SeqQ as FIFO
 import Control.Distributed.Process.Extras.Internal.Queue.SeqQ ( SeqQ )
 import qualified Control.Distributed.Process.Extras.Internal.Queue.PriorityQ as PQ
 
-import Control.Rematch hiding (on)
-import Control.Rematch.Run
 import Data.Function (on)
-import Data.List
+import Data.List ( sortBy )
 import Test.Framework as TF (defaultMain, testGroup, Test)
 import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit (Assertion, assertFailure)
+import Test.HUnit (assertBool, assertEqual)
 
 import Prelude
 
-expectThat :: a -> Matcher a -> Assertion
-expectThat a matcher = case res of
-  MatchSuccess -> return ()
-  (MatchFailure msg) -> assertFailure msg
-  where res = runMatch matcher a
 
 -- NB: these tests/properties are not meant to be complete, but rather
 -- they exercise the small number of behaviours that we actually use!
@@ -72,13 +66,11 @@ tests = [
      ],
      testGroup "FIFO Queue Tests" [
         testCase "New Queue Should Be Empty"
-          (expectThat (FIFO.isEmpty $ FIFO.empty) $ equalTo True),
+          (assertBool mempty (FIFO.isEmpty $ FIFO.empty)),
         testCase "Singleton Queue Should Contain One Element"
-          (expectThat (FIFO.dequeue $ FIFO.singleton "hello") $
-             equalTo $ Just ("hello", FIFO.empty)),
+          (assertEqual mempty (FIFO.dequeue $ FIFO.singleton "hello") $ Just ("hello", FIFO.empty)),
         testCase "Dequeue Empty Queue Should Be Nothing"
-          (expectThat (FIFO.dequeue $ (FIFO.empty :: SeqQ ())) $
-            is (Nothing :: Maybe ((), SeqQ ()))),
+          (assertEqual mempty  (FIFO.dequeue $ (FIFO.empty :: SeqQ ())) $ (Nothing :: Maybe ((), SeqQ ()))),
         testProperty "Enqueue/Dequeue should respect FIFO order"
             prop_fifo_enqueue,
         testProperty "Enqueue/Dequeue should respect isEmpty"

--- a/packages/distributed-process-extras/tests/TestTimer.hs
+++ b/packages/distributed-process-extras/tests/TestTimer.hs
@@ -9,7 +9,6 @@ import Control.Concurrent.MVar
   , takeMVar
   , withMVar
   )
-import qualified Network.Transport as NT (Transport)
 import Network.Transport.TCP()
 import Control.DeepSeq (NFData)
 import Control.Distributed.Process

--- a/packages/distributed-process-supervisor/distributed-process-supervisor.cabal
+++ b/packages/distributed-process-supervisor/distributed-process-supervisor.cabal
@@ -82,7 +82,6 @@ test-suite SupervisorTests
                    stm,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
-                   rematch >= 0.2.0.0,
                    exceptions >= 0.10 && < 0.11
   hs-source-dirs:  tests
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N -fno-warn-name-shadowing -fno-warn-unused-do-bind
@@ -111,7 +110,6 @@ test-suite NonThreadedSupervisorTests
                    stm,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
-                   rematch >= 0.2.0.0,
                    exceptions >= 0.10 && < 0.11
   hs-source-dirs:  tests
   ghc-options:     -rtsopts -fno-warn-unused-do-bind -fno-warn-name-shadowing

--- a/packages/distributed-process-systest/ChangeLog
+++ b/packages/distributed-process-systest/ChangeLog
@@ -1,3 +1,9 @@
+2024-10-30 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.4.0
+
+* Removed dependency on `rematch` (#459). This means that certain functions 
+  are no longer exported: `shouldBe`, `shouldMatch`, `shouldContain`, 
+  `shouldNotContain`, and `expectThat`.
+
 2024-09-03 Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.3.2
 
 * Bumped dependency bounds to support GHC 8.10.7 - GHC 9.10.1

--- a/packages/distributed-process-systest/distributed-process-systest.cabal
+++ b/packages/distributed-process-systest/distributed-process-systest.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          distributed-process-systest
-version:       0.3.2
+version:       0.4.0
 synopsis:      Cloud Haskell Test Support
 description:   Testing Frameworks and Capabilities for programs built on Cloud Haskell
 homepage:      http://github.com/haskell-distributed/distributed-process-systest

--- a/packages/distributed-process-systest/distributed-process-systest.cabal
+++ b/packages/distributed-process-systest/distributed-process-systest.cabal
@@ -41,7 +41,6 @@ library
                      network-transport >= 0.4.1.0 && < 0.6,
                      network >= 2.5 && < 3.3,
                      random >= 1.0 && < 1.3,
-                     rematch >= 0.1.2.1 && < 0.3,
                      test-framework >= 0.6 && < 0.9,
                      test-framework-hunit >= 0.2.0 && < 0.4,
                      exceptions < 0.11,

--- a/packages/distributed-process-systest/src/Control/Distributed/Process/SysTest/Utils.hs
+++ b/packages/distributed-process-systest/src/Control/Distributed/Process/SysTest/Utils.hs
@@ -19,11 +19,6 @@ module Control.Distributed.Process.SysTest.Utils
   -- ping !
   , Ping(Ping)
   , ping
-  , shouldBe
-  , shouldMatch
-  , shouldContain
-  , shouldNotContain
-  , expectThat
   , synchronisedAssertion
   -- test process utilities
   , TestProcessControl
@@ -77,12 +72,10 @@ import Control.Monad.Catch
 import Control.Exception (AsyncException(ThreadKilled))
 import Control.Monad (forever)
 import Control.Monad.STM (atomically)
-import Control.Rematch hiding (match)
-import Control.Rematch.Run 
 import Data.Binary
 import Data.Typeable (Typeable)
 
-import Test.HUnit (Assertion, assertFailure)
+import Test.HUnit (Assertion)
 import Test.HUnit.Base (assertBool)
 
 import GHC.Generics
@@ -127,24 +120,6 @@ synchronisedAssertion note localNode expected testProc lock = do
 
 stash :: TestResult a -> a -> Process ()
 stash mvar x = liftIO $ putMVar mvar x
-
-expectThat :: a -> Matcher a -> Process ()
-expectThat a matcher = case res of
-  MatchSuccess -> return ()
-  (MatchFailure msg) -> liftIO $ assertFailure msg
-  where res = runMatch matcher a
-
-shouldBe :: a -> Matcher a -> Process ()
-shouldBe = expectThat
-
-shouldContain :: (Show a, Eq a) => [a] -> a -> Process ()
-shouldContain xs x = expectThat xs $ hasItem (equalTo x)
-
-shouldNotContain :: (Show a, Eq a) => [a] -> a -> Process ()
-shouldNotContain xs x = expectThat xs $ isNot (hasItem (equalTo x))
-
-shouldMatch :: a -> Matcher a -> Process ()
-shouldMatch = expectThat
 
 -- | Run the supplied @testProc@ using an @MVar@ to collect and assert
 -- against its result. Uses the supplied @note@ if the assertion fails.

--- a/stack-ghc-8.10.7.yaml
+++ b/stack-ghc-8.10.7.yaml
@@ -21,5 +21,4 @@ packages:
 flags:
   distributed-process-tests:
     tcp: true
-extra-deps:
-- rematch-0.2.0.0@sha256:86019f4d6a4347e1291a0a9f85ba6324e1447e2b93d75958e59c24212e9d8178,1245
+

--- a/stack-ghc-9.0.2.yaml
+++ b/stack-ghc-9.0.2.yaml
@@ -21,5 +21,4 @@ packages:
 flags:
   distributed-process-tests:
     tcp: true
-extra-deps:
-- rematch-0.2.0.0@sha256:86019f4d6a4347e1291a0a9f85ba6324e1447e2b93d75958e59c24212e9d8178,1245
+

--- a/stack-ghc-9.2.7.yaml
+++ b/stack-ghc-9.2.7.yaml
@@ -21,5 +21,3 @@ packages:
 flags:
   distributed-process-tests:
     tcp: true
-extra-deps:
-- rematch-0.2.0.0@sha256:86019f4d6a4347e1291a0a9f85ba6324e1447e2b93d75958e59c24212e9d8178,1245

--- a/stack-ghc-9.4.5.yaml
+++ b/stack-ghc-9.4.5.yaml
@@ -21,5 +21,3 @@ packages:
 flags:
   distributed-process-tests:
     tcp: true
-extra-deps:
-- rematch-0.2.0.0@sha256:86019f4d6a4347e1291a0a9f85ba6324e1447e2b93d75958e59c24212e9d8178,1245

--- a/stack-ghc-9.8.2.yaml
+++ b/stack-ghc-9.8.2.yaml
@@ -21,5 +21,3 @@ packages:
 flags:
   distributed-process-tests:
     tcp: true
-extra-deps:
-- rematch-0.2.0.0@sha256:86019f4d6a4347e1291a0a9f85ba6324e1447e2b93d75958e59c24212e9d8178,1245


### PR DESCRIPTION
This PR removes the `rematch` dependency, which hasn't been maintained in the last decade. 

Fixes #458 