### PR TITLE
Bump version number for distributed-process-tests

### DIFF
--- a/packages/distributed-process-tests/distributed-process-tests.cabal
+++ b/packages/distributed-process-tests/distributed-process-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          distributed-process-tests
-version:       0.4.13
+version:       0.5.1
 synopsis:      Tests and test support tools for distributed-process.
 homepage:      http://github.com/haskell-distributed/distributed-process/tree/master/distributed-process-tests
 description:   Tests and test suite for Cloud Haskell libraries, specifically the core distributed-process library.


### PR DESCRIPTION
This pull request just bumps the version number for `distributed-process-test` from 0.4.13 to 0.5.1. The reason was that hackage had an older version of `distributed-process-test` (uploaded 2024-08-28) that had a higher version number: 0.5.0, while the newest version (uploaded 2024-09-03) had version number 0.4.13. 