### PR TITLE
General tidy up of dependencies and warnings

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -2,10 +2,12 @@ name: Continuous integration
 
 on:
   push:
+    branches: ['master']
     paths-ignore:
       - 'README.md'
       - 'CONTRIBUTING.md'
   pull_request:
+    branches: ['master']
 
 jobs:
   continuous-integration:

--- a/packages/distributed-process-async/distributed-process-async.cabal
+++ b/packages/distributed-process-async/distributed-process-async.cabal
@@ -38,19 +38,10 @@ library
   import:          warnings
   build-depends:
                    base >= 4.14 && < 5,
-                   data-accessor >= 0.2.2.3,
                    distributed-process >= 0.6.1 && < 0.8,
                    exceptions >= 0.10 && < 1.0,
                    binary >= 0.8 && < 0.9,
-                   deepseq >= 1.4 && < 1.7,
-                   mtl,
-                   containers >= 0.6 && < 0.8,
-                   hashable >= 1.2.0.5 && < 1.6,
-                   unordered-containers >= 0.2.3.0 && < 0.3,
-                   fingertree < 0.2,
                    stm >= 2.4 && < 2.6,
-                   time >= 1.9,
-                   transformers
   default-extensions:      CPP
                    InstanceSigs
   hs-source-dirs:   src
@@ -66,20 +57,14 @@ test-suite AsyncTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.14 && < 5,
-                   ansi-terminal >= 0.5 && < 1.2,
                    distributed-process,
                    distributed-process-async,
                    distributed-process-systest ^>= 0.4,
-                   exceptions >= 0.10 && < 1.0,
-                   network >= 2.5 && < 3.3,
                    network-transport >= 0.4 && < 0.6,
                    network-transport-tcp >= 0.6 && < 0.9,
                    binary >= 0.8 && < 0.9,
-                   deepseq >= 1.4 && < 1.7,
-                   stm >= 2.3 && < 2.6,
                    tasty >= 1.5 && <1.6,
                    tasty-hunit >=0.10 && <0.11,
-                   transformers
   hs-source-dirs:  tests
   default-language: Haskell2010
   ghc-options:     -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind

--- a/packages/distributed-process-client-server/distributed-process-client-server.cabal
+++ b/packages/distributed-process-client-server/distributed-process-client-server.cabal
@@ -46,12 +46,8 @@ library
                    deepseq >= 1.4 && < 1.7,
                    mtl,
                    containers >= 0.6 && < 0.8,
-                   hashable >= 1.2.0.5 && < 1.6,
-                   unordered-containers >= 0.2.3.0 && < 0.3,
                    fingertree < 0.2,
                    stm >= 2.4 && < 2.6,
-                   time > 1.4 && < 1.15,
-                   transformers,
                    exceptions >= 0.10 && < 0.11
   hs-source-dirs:   src
   exposed-modules:
@@ -74,25 +70,17 @@ test-suite ManagedProcessTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.14 && < 5,
-                   ansi-terminal >= 0.5 && < 1.2,
-                   containers,
                    distributed-process,
                    distributed-process-extras,
                    distributed-process-async,
                    distributed-process-client-server,
                    distributed-process-systest ^>= 0.4,
                    network-transport >= 0.4 && < 0.7,
-                   mtl,
-                   fingertree,
                    network-transport-tcp >= 0.6 && < 0.9,
                    binary >= 0.8 && < 0.9,
-                   deepseq,
-                   network >= 2.3 && < 3.3,
                    stm,
                    tasty >= 1.5 && <1.6,
                    tasty-hunit >=0.10 && <0.11,
-                   transformers,
-                   ghc-prim,
                    exceptions
   other-modules:   Counter,
                    ManagedProcessCommon,
@@ -111,25 +99,18 @@ test-suite PrioritisedProcessTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.14 && < 5,
-                   ansi-terminal,
-                   containers,
                    distributed-process,
                    distributed-process-extras,
                    distributed-process-async,
                    distributed-process-client-server,
                    distributed-process-systest ^>= 0.4,
                    network-transport,
-                   mtl,
-                   fingertree,
                    network-transport-tcp,
                    binary,
                    deepseq,
-                   network,
                    stm,
                    tasty >= 1.5 && <1.6,
                    tasty-hunit >=0.10 && <0.11,
-                   transformers,
-                   ghc-prim,
                    exceptions
   other-modules:   ManagedProcessCommon,
                    TestUtils

--- a/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess.hs
+++ b/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess.hs
@@ -651,7 +651,6 @@ module Control.Distributed.Process.ManagedProcess
 import Control.Distributed.Process hiding (call, Message)
 import Control.Distributed.Process.ManagedProcess.Client
 import Control.Distributed.Process.ManagedProcess.Server
-import qualified Control.Distributed.Process.ManagedProcess.Server.Restricted as R
 import qualified Control.Distributed.Process.ManagedProcess.Server.Priority as P hiding (reject)
 import qualified Control.Distributed.Process.ManagedProcess.Internal.GenProcess as Gen
 import Control.Distributed.Process.ManagedProcess.Internal.GenProcess

--- a/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess/Server/Gen.hs
+++ b/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess/Server/Gen.hs
@@ -97,7 +97,6 @@ import qualified Control.Distributed.Process.ManagedProcess.Internal.GenProcess 
  , modifyState
  , setUserTimeout
  , setProcessState
- , GenProcess
  , peek
  , push
  , enqueue

--- a/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess/Timer.hs
+++ b/packages/distributed-process-client-server/src/Control/Distributed/Process/ManagedProcess/Timer.hs
@@ -67,7 +67,6 @@ import Control.Distributed.Process.Extras.Timer
 import Data.Binary (Binary)
 import Data.Maybe (isJust, fromJust)
 import Data.Typeable (Typeable)
-import GHC.Conc (registerDelay)
 import GHC.Generics
 
 --------------------------------------------------------------------------------

--- a/packages/distributed-process-extras/src/Control/Distributed/Process/Extras/Internal/Containers/MultiMap.hs
+++ b/packages/distributed-process-extras/src/Control/Distributed/Process/Extras/Internal/Containers/MultiMap.hs
@@ -21,13 +21,11 @@ module Control.Distributed.Process.Extras.Internal.Containers.MultiMap
 
 import qualified Data.Foldable as Foldable
 import Data.Foldable (Foldable)
-
 import Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as Map
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as Set
-import Data.Foldable (Foldable(foldr))
 import Prelude hiding (lookup, filter, pred)
 
 -- | Class of things that can be inserted in a map or

--- a/packages/distributed-process-extras/tests/TestQueues.hs
+++ b/packages/distributed-process-extras/tests/TestQueues.hs
@@ -9,7 +9,7 @@ import qualified Control.Distributed.Process.Extras.Internal.Queue.PriorityQ as 
 import Data.Function (on)
 import Data.List ( sortBy )
 import Test.Tasty (TestTree, testGroup, defaultMain)
-import Test.Tasty.HUnit (Assertion, assertEqual, assertBool, testCase)
+import Test.Tasty.HUnit (assertEqual, assertBool, testCase)
 import Test.Tasty.QuickCheck (testProperty)
 
 import Prelude

--- a/packages/distributed-process-extras/tests/TestTimer.hs
+++ b/packages/distributed-process-extras/tests/TestTimer.hs
@@ -19,7 +19,7 @@ import Control.Distributed.Process.Extras.Timer
 import Control.Distributed.Process.SysTest.Utils
 
 import Test.Tasty (TestTree, testGroup, defaultMain)
-import Test.Tasty.HUnit (Assertion, assertEqual, assertBool, testCase)
+import Test.Tasty.HUnit (testCase)
 import Network.Transport.TCP
 import qualified Network.Transport as NT
 

--- a/packages/distributed-process-simplelocalnet/distributed-process-simplelocalnet.cabal
+++ b/packages/distributed-process-simplelocalnet/distributed-process-simplelocalnet.cabal
@@ -45,7 +45,6 @@ Library
                      data-accessor >= 0.2 && < 0.3,
                      binary >= 0.8 && < 0.9,
                      containers >= 0.6 && < 0.8,
-                     transformers >= 0.2 && < 0.7,
                      network-transport >= 0.5 && < 0.6,
                      network-transport-tcp >= 0.4 && < 0.9,
                      distributed-process >= 0.5.0 && < 0.8

--- a/packages/distributed-process-simplelocalnet/tests/Main.hs
+++ b/packages/distributed-process-simplelocalnet/tests/Main.hs
@@ -2,17 +2,17 @@
 
 import Control.Concurrent (forkIO, threadDelay)
 import qualified Control.Concurrent.MVar as MVar
-import Control.Distributed.Process (NodeId, Process, liftIO)
 import Control.Distributed.Process.Node (initRemoteTable)
 import Control.Distributed.Process.Backend.SimpleLocalnet
 import Control.Monad (forM_)
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.List as List
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (assertEqual, testCase)
 
 main :: IO ()
-main = defaultMain 
-     $ testGroup "Test suite" 
+main = defaultMain
+     $ testGroup "Test suite"
      [ testDiscoverNodes
      ]
 
@@ -24,7 +24,7 @@ testDiscoverNodes = testCase "discover nodes" $ do
     backend <- initializeBackend "127.0.0.1" port initRemoteTable
     _ <- forkIO $ startSlave backend
     threadDelay 100000
-  
+
   -- initialize master node
   discoveredNodesSlot <- MVar.newEmptyMVar
   backend <- initializeBackend "127.0.0.1" "10004" initRemoteTable
@@ -33,12 +33,12 @@ testDiscoverNodes = testCase "discover nodes" $ do
     liftIO $ MVar.putMVar discoveredNodesSlot nds
 
   discoveredNodes <- (List.sort . List.nub) <$> MVar.readMVar discoveredNodesSlot
-  assertEqual "Discovered nodes" 
+  assertEqual "Discovered nodes"
               [ "nid://127.0.0.1:10000:0"
               , "nid://127.0.0.1:10001:0"
               , "nid://127.0.0.1:10002:0"
               , "nid://127.0.0.1:10003:0"
-              ] 
+              ]
               (map show discoveredNodes)
 
 

--- a/packages/distributed-process-supervisor/src/Control/Distributed/Process/Supervisor/Management.hs
+++ b/packages/distributed-process-supervisor/src/Control/Distributed/Process/Supervisor/Management.hs
@@ -52,7 +52,6 @@ import Control.Distributed.Process.Supervisor.Types
   , SupervisorPid
   )
 import Data.Binary
-import Data.Foldable (mapM_)
 import Data.Hashable (Hashable(..))
 import Control.Distributed.Process.Extras.Internal.Containers.MultiMap (MultiMap)
 import qualified Control.Distributed.Process.Extras.Internal.Containers.MultiMap as Map

--- a/packages/distributed-process/distributed-process.cabal
+++ b/packages/distributed-process/distributed-process.cabal
@@ -52,7 +52,6 @@ Library
                      hashable >= 1.2.0.5 && < 1.6,
                      network-transport >= 0.4.1.0 && < 0.6,
                      stm >= 2.4 && < 2.6,
-                     transformers >= 0.2 && < 0.7,
                      mtl >= 2.0 && < 2.4,
                      data-accessor >= 0.2 && < 0.3,
                      bytestring >= 0.10 && < 0.13,

--- a/packages/network-transport-inmemory/tests/TestInMemory.hs
+++ b/packages/network-transport-inmemory/tests/TestInMemory.hs
@@ -4,7 +4,6 @@ import Network.Transport.Tests
 import Network.Transport.Tests.Auxiliary (runTests)
 import Network.Transport.InMemory
 import Network.Transport
-import Control.Applicative ((<$>))
 
 main :: IO ()
 main = do

--- a/packages/network-transport-tcp/tests/TestTCP.hs
+++ b/packages/network-transport-tcp/tests/TestTCP.hs
@@ -27,14 +27,11 @@ import Control.Concurrent.MVar ( MVar
                                , putMVar
                                , takeMVar
                                , readMVar
-                               , isEmptyMVar
                                , newMVar
                                , modifyMVar
                                , modifyMVar_
-                               , swapMVar
                                )
-import Control.Monad (replicateM, guard, forM_, replicateM_, when)
-import Control.Applicative ((<$>))
+import Control.Monad (replicateM, guard, replicateM_, when)
 import Control.Exception (throwIO, try, SomeException)
 import Network.Transport.TCP ( socketToEndPoint )
 import Network.Transport.Internal ( prependLength
@@ -48,7 +45,6 @@ import Network.Transport.TCP.Internal
   , decodeControlHeader
   , ConnectionRequestResponse(..)
   , encodeConnectionRequestResponse
-  , decodeConnectionRequestResponse
   , encodeWord32
   , recvWord32
   , forkServer
@@ -63,12 +59,10 @@ import qualified Network.Transport.TCP.Mock.Socket as N
 import qualified Network.Socket as N
 #endif
   ( close
-  , ServiceName
   , Socket
   , AddrInfo
   , shutdown
   , ShutdownCmd(ShutdownSend)
-  , SockAddr(..)
   , SocketType(Stream)
   , AddrInfo(..)
   , getAddrInfo

--- a/packages/network-transport-tests/src/Network/Transport/Tests.hs
+++ b/packages/network-transport-tests/src/Network/Transport/Tests.hs
@@ -20,7 +20,6 @@ import Control.Exception
   )
 import Control.Monad (replicateM, replicateM_, when, guard, forM_, unless)
 import Control.Monad.Except ()
-import Control.Applicative ((<$>))
 import Network.Transport
 import Network.Transport.Internal (tlog, tryIO, timeoutMaybe)
 import Network.Transport.Util (spawn)
@@ -652,7 +651,7 @@ testCloseEndPoint transport _ = do
 
     -- First test (see client)
     do
-      theirAddr <- readMVar clientAddr1
+      _theirAddr <- readMVar clientAddr1
       ConnectionOpened cid ReliableOrdered addr <- receive endpoint
       -- Ensure that connecting to the supplied address reaches the peer.
       Right conn <- connect endpoint addr ReliableOrdered defaultConnectHints
@@ -716,7 +715,7 @@ testCloseEndPoint transport _ = do
       send conn ["ping"]
 
       -- Reply from the server
-      ConnectionOpened cid ReliableOrdered addr <- receive endpoint
+      ConnectionOpened cid ReliableOrdered _addr <- receive endpoint
       Received cid' ["pong"] <- receive endpoint ; True <- return $ cid == cid'
 
       -- Close the endpoint

--- a/packages/network-transport-tests/src/Network/Transport/Tests/Traced.hs
+++ b/packages/network-transport-tests/src/Network/Transport/Tests/Traced.hs
@@ -60,7 +60,6 @@ import Prelude hiding
   )
 import qualified Prelude
 import Control.Exception (catches, Handler(..), SomeException, throwIO, Exception(..), IOException)
-import Control.Applicative ((<$>))
 import Data.Typeable (Typeable)
 import Data.Maybe (catMaybes)
 import Data.ByteString (ByteString)

--- a/packages/network-transport/src/Network/Transport/Internal.hs
+++ b/packages/network-transport/src/Network/Transport/Internal.hs
@@ -27,7 +27,7 @@ module Network.Transport.Internal
 import Foreign.Storable (pokeByteOff, peekByteOff)
 import Foreign.ForeignPtr (withForeignPtr)
 import Data.ByteString (ByteString)
-import Data.List (foldl')
+import Data.List(foldl')
 import qualified Data.ByteString as BS (length)
 import qualified Data.ByteString.Internal as BSI
   ( unsafeCreate

--- a/packages/rank1dynamic/rank1dynamic.cabal
+++ b/packages/rank1dynamic/rank1dynamic.cabal
@@ -49,7 +49,6 @@ Test-Suite TestRank1Dynamic
   Type:              exitcode-stdio-1.0
   Main-Is:           test.hs
   Build-Depends:     base >= 4.14 && < 5,
-                     HUnit >= 1.2 && < 1.7,
                      rank1dynamic,
                      tasty >= 1.5 && <1.6,
                      tasty-hunit >=0.10 && <0.11,


### PR DESCRIPTION
Thank you for picking up maintenance of this package.

I've done some hopefully useful (and non-controversial) fixes to cabal files, source files and CI setup.
I don't think this introduces any regressions but I have seen intermittent failures on the testsuite that are fixable by re-running the tests. The test suite needs work to make it more reliable, which I've not done here.

* a1071e6ecc03ec619b9dc5b497a31dd6c5e7e288 removes unnecessary package depdendencies.
* b601ed10a33577ff9a299b548eb213b786bb547e changes GH CI so it will only build once per PR. Previously it was running two identical builds for PRs.
* e3196db70e16e54393c17c927a6f87c26f678fe2 removes unnecessary imports, exports and variable bindings.