### PR TITLE
Testing with GHC 9.14

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -37,6 +37,9 @@ jobs:
             cabal-flags: ""
           - ghc-version: "9.12.2"
             cabal-flags: ""
+          - ghc-version: "9.14.1"
+            # See issue 479 for when we can drop the following flags
+            cabal-flags: "--allow-newer=base --allow-newer=ghc-bignum --allow-newer=containers --allow-newer=template-haskell"
 
     runs-on: "ubuntu-latest"
 
@@ -48,14 +51,14 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-version }}
-        cabal-version: '3.12.1.0'
+        cabal-version: '3.16.1.0'
 
     - name: Generate freeze file
       run: |
         # Cloud Haskell tests using the QUIC backend are quite flaky, but in CI only.
         # Therefore, the 'quic' flag is normally enabled locally, but disabled in CI. 
-        cabal configure --enable-tests --test-show-details=direct --flags "-quic"
-        cabal freeze ${{matrix.cabal-flags}} --minimize-conflict-set
+        cabal configure --enable-tests --test-show-details=direct --flags "-quic" ${{matrix.cabal-flags}}
+        cabal freeze --minimize-conflict-set
         cat cabal.project.freeze
 
     - name: Cache cabal work
@@ -69,15 +72,15 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('cabal.project', 'cabal.project.local') }}-cabal-install
 
     - name: Build dependencies only
-      run: cabal build all --only-dependencies ${{matrix.cabal-flags}}
+      run: cabal build all --only-dependencies
 
     - name: Build all packages
-      run: cabal build all ${{matrix.cabal-flags}}
+      run: cabal build all
 
     - name: Run all tests
       # We have seen in the past some tests hang for hours, wasting resources.
       # The timeout below should be plenty
       timeout-minutes: 10
       # We run each test suite one-by-one to better observe problems.
-      run: cabal test all -j1 ${{matrix.cabal-flags}}
+      run: cabal test all -j1 
 

--- a/packages/distributed-process-async/distributed-process-async.cabal
+++ b/packages/distributed-process-async/distributed-process-async.cabal
@@ -15,7 +15,7 @@ description:    This package provides a higher-level interface over Processes, i
                 concurrent, possibly distributed Process that will eventually deliver a value of type a.
                 The package provides ways to create Async computations, wait for their results, and cancel them.
 category:       Control
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-doc-files: CHANGELOG.md
 
 source-repository head

--- a/packages/distributed-process-client-server/distributed-process-client-server.cabal
+++ b/packages/distributed-process-client-server/distributed-process-client-server.cabal
@@ -16,7 +16,7 @@ description:    Modelled after Erlang OTP's gen_server, this framework provides 
                 development into a set of modules and standards designed to help you build
                 concurrent, distributed applications with relative ease.
 category:       Control
-tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-doc-files: CHANGELOG.md
 
 source-repository head

--- a/packages/distributed-process-execution/distributed-process-execution.cabal
+++ b/packages/distributed-process-execution/distributed-process-execution.cabal
@@ -16,7 +16,7 @@ description:
                 The currently implementation provides only a subset of the plumbing required, comprising tools
                 for event management, mailbox buffering and message routing.
 category:       Control
-tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-doc-files: ChangeLog
 
 source-repository head

--- a/packages/distributed-process-extras/distributed-process-extras.cabal
+++ b/packages/distributed-process-extras/distributed-process-extras.cabal
@@ -14,7 +14,7 @@ synopsis:       Cloud Haskell Extras
 description:    Supporting library, providing common types and utilities used by the
                 various libraries built on top of distributed-process
 category:       Control
-tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-doc-files: ChangeLog
 
 source-repository head

--- a/packages/distributed-process-fsm/distributed-process-fsm.cabal
+++ b/packages/distributed-process-fsm/distributed-process-fsm.cabal
@@ -13,7 +13,7 @@ Bug-Reports:    http://github.com/haskell-distributed/distributed-process-fsm/is
 synopsis:       The Cloud Haskell implementation of Erlang/OTP gen_statem
 description:    Cloud Haskell framework for building finite state machines around CSPs
 category:       Control
-Tested-With:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+Tested-With:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 
 source-repository head
   type:      git

--- a/packages/distributed-process-simplelocalnet/distributed-process-simplelocalnet.cabal
+++ b/packages/distributed-process-simplelocalnet/distributed-process-simplelocalnet.cabal
@@ -15,7 +15,7 @@ Description:   Simple backend based on the TCP transport which offers node
                discovery based on UDP multicast. This is a zero-configuration
                backend designed to get you going with Cloud Haskell quickly
                without imposing any structure on your application.
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 Category:      Control
 extra-doc-files: ChangeLog
 

--- a/packages/distributed-process-supervisor/distributed-process-supervisor.cabal
+++ b/packages/distributed-process-supervisor/distributed-process-supervisor.cabal
@@ -20,7 +20,7 @@ description:    A part of the Cloud Haskell framework
 
                 For detailed information see "Control.Distributed.Process.Supervisor"
 category:       Control
-tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:    GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-doc-files: ChangeLog
 
 source-repository head

--- a/packages/distributed-process-tests/distributed-process-tests.cabal
+++ b/packages/distributed-process-tests/distributed-process-tests.cabal
@@ -11,7 +11,7 @@ maintainer:    The Distributed Haskell team
 copyright:     Well-Typed LLP
 category:      Control, Cloud Haskell
 build-type:    Simple
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 extra-source-files:
                tests/credentials/cert.crt
                tests/credentials/cert.key

--- a/packages/distributed-process/distributed-process.cabal
+++ b/packages/distributed-process/distributed-process.cabal
@@ -21,7 +21,7 @@ Description:   This is an implementation of Cloud Haskell, as described in
 
                You will probably also want to install a Cloud Haskell backend such
                as distributed-process-simplelocalnet.
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1 GHC==9.14.1
 Category:      Control
 extra-doc-files: ChangeLog
 

--- a/packages/distributed-static/distributed-static.cabal
+++ b/packages/distributed-static/distributed-static.cabal
@@ -25,7 +25,7 @@ Copyright:           Well-Typed LLP
 Category:            Control
 Build-Type:          Simple
 extra-doc-files:     ChangeLog
-tested-with:         GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:         GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 
 source-repository head
   Type:     git

--- a/packages/network-transport-inmemory/network-transport-inmemory.cabal
+++ b/packages/network-transport-inmemory/network-transport-inmemory.cabal
@@ -21,7 +21,7 @@ Description:   This is a transport implementation that could be used for local
                communication. All endpoints that want to communicate should be
                created using the same transport.
 
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 Category:      Network
 extra-doc-files: ChangeLog
 

--- a/packages/network-transport-quic/network-transport-quic.cabal
+++ b/packages/network-transport-quic/network-transport-quic.cabal
@@ -20,7 +20,7 @@ Description:
 
   In dense network topologies, using ["Network.Transport.QUIC"] may improve performance by a factor of 2 over
   other transport implementations.
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 Category:      Network
 extra-doc-files:
                README.md

--- a/packages/network-transport-tcp/network-transport-tcp.cabal
+++ b/packages/network-transport-tcp/network-transport-tcp.cabal
@@ -12,7 +12,7 @@ Homepage:      https://haskell-distributed.github.io
 Bug-Reports:   https://github.com/haskell-distributed/distributed-process/issues
 Synopsis:      TCP instantiation of Network.Transport
 Description:   TCP instantiation of Network.Transport, which can be used to create Cloud Haskell backends
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 Category:      Network
 extra-doc-files: ChangeLog
 

--- a/packages/network-transport/network-transport.cabal
+++ b/packages/network-transport/network-transport.cabal
@@ -55,7 +55,7 @@ Description:   "Network.Transport" is a Network Abstraction Layer which provides
                This package provides the generic interface only; you will
                probably also want to install at least one transport
                implementation (network-transport-*).
-tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:   GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 Category:      Network
 extra-doc-files: ChangeLog
 

--- a/packages/rank1dynamic/rank1dynamic.cabal
+++ b/packages/rank1dynamic/rank1dynamic.cabal
@@ -15,7 +15,7 @@ Copyright:           Well-Typed LLP, Tweag I/O Limited
 Category:            Data
 Build-Type:          Simple
 extra-doc-files:     ChangeLog
-tested-with:         GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2
+tested-with:         GHC==8.10.7 GHC==9.0.2 GHC==9.2.8 GHC==9.4.8 GHC==9.6.7 GHC==9.8.4 GHC==9.10.3 GHC==9.12.2 GHC==9.14.1
 
 source-repository head
   Type:     git


### PR DESCRIPTION
This PR adds CI testing with GHC 9.14. All packages in this repository already build with GHC 9.14, so we just have to wait for the dependencies (see related issue).

Fixes #479 