### PR TITLE
Addressed race conditions and flaky tests in QUIC transport

### DIFF
--- a/packages/network-transport-quic/CHANGELOG.md
+++ b/packages/network-transport-quic/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Eliminated a rare race condition that allowed the transport to read messages before
   marking the connection as open, violating the interface expectations.
+* Better handling of lost connections
 
 2026-01-01  Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.1.1
 

--- a/packages/network-transport-quic/CHANGELOG.md
+++ b/packages/network-transport-quic/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 * Eliminated a rare race condition that allowed the transport to read messages before
   marking the connection as open, violating the interface expectations.
-* Better handling of lost connections
+* Better handling of lost connections.
+* Fixed rare race condition in establishing connections.
 
 2026-01-01  Laurent P. René de Cotret <laurent.decotret@outlook.com> 0.1.1
 

--- a/packages/network-transport-quic/bench/Bench.hs
+++ b/packages/network-transport-quic/bench/Bench.hs
@@ -58,7 +58,15 @@ quicConfig =
           >>= \case
             Left errmsg -> throwIO $ userError errmsg
             Right credentials ->
-              QUIC.createTransport "127.0.0.1" "0" (credentials :| [])
+              QUIC.createTransport
+                ( QUIC.QUICTransportConfig
+                    { hostName = "127.0.0.1"
+                    , serviceName = "0"
+                    , credentials = credentials :| []
+                    , -- credentials are self-signed
+                      validateCredentials = False
+                    }
+                )
     }
 
 data BenchParams = BenchParams
@@ -115,8 +123,7 @@ throughputBench TransportConfig{mkTransport} BenchParams{messageSize, messageCou
     connections <-
       replicateM
         connectionCount
-        ( connect senderEP receiverAddr ReliableOrdered defaultConnectHints >>= either throwIO pure
-        )
+        (connect senderEP receiverAddr ReliableOrdered defaultConnectHints >>= either throwIO pure)
 
     takeMVar receiverReady
 

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
@@ -22,7 +22,7 @@ module Network.Transport.QUIC.Internal
 where
 
 import Control.Concurrent (forkIO, killThread, modifyMVar_, newEmptyMVar, readMVar)
-import Control.Concurrent.MVar (modifyMVar, putMVar, takeMVar, withMVar)
+import Control.Concurrent.MVar (modifyMVar, putMVar, takeMVar, tryPutMVar, withMVar)
 import Control.Concurrent.STM (atomically, newTQueueIO)
 import Control.Concurrent.STM.TQueue
   ( TQueue,
@@ -181,10 +181,6 @@ handleNewStream quicTransport stream = do
 
                     (remoteEndPoint, _) <- either throwIO pure =<< createRemoteEndPoint ourEndPoint remoteAddress Incoming
                     doneMVar <- newEmptyMVar
-
-                    -- Sending an ack is important, because otherwise
-                    -- the client may start sending messages well before we
-                    -- start being able to receive them
 
                     clientConnId <- either (throwIO . userError) (pure . fromIntegral) =<< recvWord32 stream
                     let serverConnId = remoteServerConnId remoteEndPoint
@@ -401,9 +397,14 @@ newConnection ourEndPoint creds validateCreds remoteAddress _reliability _connec
             False -> pure (RemoteEndPointValid vst, Nothing)
             True -> do
               writeIORef connAlive False
-              -- We want to run this cleanup action OUTSIDE of the MVar modification
-              let cleanup = sendCloseConnection connId stream
-              pure (RemoteEndPointClosed, Just $ cleanup >> putMVar isClosed ())
+              -- Run cleanup OUTSIDE the MVar modification. tryPutMVar keeps this
+              -- safe against races with the finally in streamToEndpoint that can
+              -- also signal isClosed on QUIC.Client.run exit.
+              let cleanup = do
+                    _ <- sendCloseConnection connId stream
+                    _ <- tryPutMVar isClosed ()
+                    pure ()
+              pure (RemoteEndPointClosed, Just cleanup)
         _ -> pure (RemoteEndPointClosed, Nothing)
 
       case mCleanup of

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
@@ -218,6 +218,13 @@ handleNewStream quicTransport stream = do
                             remoteAddress
                         )
 
+                    -- Second handshake ack: only sent after ConnectionOpened is
+                    -- enqueued. The initiator's @connect@ call blocks on this ack, so
+                    -- when it returns, the caller can trust that any peer observing
+                    -- events on this endpoint will see ConnectionOpened before any
+                    -- messages the caller subsequently sends on other connections.
+                    sendAck stream
+
                     tid <-
                       forkIO $
                         handleIncomingMessages

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal.hs
@@ -34,13 +34,11 @@ import Control.Monad (unless, when)
 import Data.Bifunctor (Bifunctor (first))
 import Data.Binary qualified as Binary (decodeOrFail)
 import Data.ByteString (ByteString, fromStrict)
-import Data.Foldable (forM_)
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (isNothing)
 import Lens.Micro.Platform ((+~))
 import Network.QUIC qualified as QUIC
 import Network.TLS (Credential)
@@ -62,8 +60,7 @@ import Network.Transport
   )
 import Network.Transport.QUIC.Internal.Configuration (credentialLoadX509)
 import Network.Transport.QUIC.Internal.Messaging
-  ( ClientConnId,
-    MessageReceived (..),
+  ( MessageReceived (..),
     createConnectionId,
     decodeMessage,
     encodeMessage,
@@ -101,7 +98,6 @@ import Network.Transport.QUIC.Internal.QUICTransport
     nextSelfConnOutId,
     remoteEndPointAddress,
     remoteEndPointState,
-    remoteIncoming,
     remoteServerConnId,
     remoteStream,
     transportConfig,
@@ -182,17 +178,15 @@ handleNewStream quicTransport stream = do
                     (remoteEndPoint, _) <- either throwIO pure =<< createRemoteEndPoint ourEndPoint remoteAddress Incoming
                     doneMVar <- newEmptyMVar
 
-                    clientConnId <- either (throwIO . userError) (pure . fromIntegral) =<< recvWord32 stream
                     let serverConnId = remoteServerConnId remoteEndPoint
-                        connectionId = createConnectionId serverConnId clientConnId
+                        -- One logical connection per stream; clientConnId is always 0.
+                        connectionId = createConnectionId serverConnId 0
 
                     let st =
                           RemoteEndPointValid $
                             ValidRemoteEndPointState
                               { _remoteStream = stream,
-                                _remoteStreamIsClosed = doneMVar,
-                                _remoteIncoming = Just clientConnId,
-                                _remoteNextConnOutId = 0
+                                _remoteStreamIsClosed = doneMVar
                               }
                     modifyMVar_
                       (remoteEndPoint ^. remoteEndPointState)
@@ -253,12 +247,8 @@ handleIncomingMessages ourEndPoint remoteEndPoint =
     release (Left err) = closeRemoteEndPoint Incoming remoteEndPoint >> prematureExit err
     release (Right _) = closeRemoteEndPoint Incoming remoteEndPoint
 
-    connectionId = createConnectionId serverConnId
-
-    writeConnectionClosedSTM connId =
-      writeTQueue
-        ourQueue
-        (ConnectionClosed (connectionId connId))
+    -- One logical connection per stream; clientConnId is always 0.
+    connectionId = createConnectionId serverConnId 0
 
     go = either prematureExit loop
 
@@ -268,34 +258,31 @@ handleIncomingMessages ourEndPoint remoteEndPoint =
           Left errmsg -> do
             -- Throwing will trigger 'prematureExit'
             throwIO $ userError $ "(handleIncomingMessages) Failed with: " <> errmsg
-          Right (Message connId bytes) -> handleMessage connId bytes >> loop stream
+          Right (Message bytes) -> handleMessage bytes >> loop stream
           Right StreamClosed -> throwIO $ userError "(handleIncomingMessages) Stream closed"
-          Right (CloseConnection connId) -> do
-            atomically (writeConnectionClosedSTM connId)
+          Right CloseConnection -> do
+            atomically (writeTQueue ourQueue (ConnectionClosed connectionId))
             mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
               RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
               RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
-              RemoteEndPointValid (ValidRemoteEndPointState _ isClosed _ _) -> do
+              RemoteEndPointValid (ValidRemoteEndPointState _ isClosed) -> do
                 pure (RemoteEndPointClosed, Just $ putMVar isClosed ())
             case mAct of
               Nothing -> pure ()
               Just cleanup -> cleanup
           Right CloseEndPoint -> do
-            connIds <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
-              RemoteEndPointValid vst -> do
-                pure (RemoteEndPointClosed, vst ^. remoteIncoming)
-              other -> pure (other, Nothing)
-            unless
-              (isNothing connIds)
-              ( atomically $
-                  forM_
-                    connIds
-                    (writeTQueue ourQueue . ConnectionClosed . connectionId)
-              )
+            -- handleIncomingMessages only runs on incoming remote endpoints, so if
+            -- the state was still Valid there is exactly one logical connection to
+            -- surface as closed.
+            wasValid <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
+              RemoteEndPointValid _ -> pure (RemoteEndPointClosed, True)
+              other -> pure (other, False)
+            when wasValid $
+              atomically $ writeTQueue ourQueue (ConnectionClosed connectionId)
 
-    handleMessage :: ClientConnId -> [ByteString] -> IO ()
-    handleMessage clientConnId payload =
-      atomically (writeTQueue ourQueue (Received (connectionId clientConnId) payload))
+    handleMessage :: [ByteString] -> IO ()
+    handleMessage payload =
+      atomically (writeTQueue ourQueue (Received connectionId payload))
 
     prematureExit :: IOException -> IO ()
     prematureExit exc = do
@@ -363,24 +350,24 @@ newConnection ourEndPoint creds validateCreds remoteAddress _reliability _connec
     else
       createConnectionTo creds validateCreds ourEndPoint remoteAddress >>= \case
         Left err -> pure $ Left err
-        Right (remoteEndPoint, connId) -> do
+        Right remoteEndPoint -> do
           connAlive <- newIORef True
           pure
             . Right
             $ Connection
-              { send = sendConn remoteEndPoint connAlive connId,
-                close = closeConn remoteEndPoint connAlive connId
+              { send = sendConn remoteEndPoint connAlive,
+                close = closeConn remoteEndPoint connAlive
               }
   where
     ourAddress = ourEndPoint ^. localAddress
-    sendConn remoteEndPoint connAlive connId packets =
+    sendConn remoteEndPoint connAlive packets =
       readMVar (remoteEndPoint ^. remoteEndPointState) >>= \case
         RemoteEndPointInit -> undefined
         RemoteEndPointValid vst ->
           readIORef connAlive >>= \case
             False -> pure . Left $ TransportError SendClosed "Connection closed"
             True ->
-              sendMessage (vst ^. remoteStream) connId packets
+              sendMessage (vst ^. remoteStream) packets
                 <&> first (TransportError SendFailed . show)
         RemoteEndPointClosed -> do
           readIORef connAlive >>= \case
@@ -390,9 +377,9 @@ newConnection ourEndPoint creds validateCreds remoteAddress _reliability _connec
             -- 'connAlive' IORefs.
             False -> pure . Left $ TransportError SendClosed "Connection closed"
             True -> pure . Left $ TransportError SendFailed "Remote endpoint closed"
-    closeConn remoteEndPoint connAlive connId = do
+    closeConn remoteEndPoint connAlive = do
       mCleanup <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
-        RemoteEndPointValid vst@(ValidRemoteEndPointState stream isClosed _ _) -> do
+        RemoteEndPointValid vst@(ValidRemoteEndPointState stream isClosed) -> do
           readIORef connAlive >>= \case
             False -> pure (RemoteEndPointValid vst, Nothing)
             True -> do
@@ -401,7 +388,7 @@ newConnection ourEndPoint creds validateCreds remoteAddress _reliability _connec
               -- safe against races with the finally in streamToEndpoint that can
               -- also signal isClosed on QUIC.Client.run exit.
               let cleanup = do
-                    _ <- sendCloseConnection connId stream
+                    _ <- sendCloseConnection stream
                     _ <- tryPutMVar isClosed ()
                     pure ()
               pure (RemoteEndPointClosed, Just cleanup)

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
@@ -17,7 +17,7 @@ import Network.QUIC qualified as QUIC
 import Network.QUIC.Client qualified as QUIC.Client
 import Network.Transport (ConnectErrorCode (ConnectNotFound), EndPointAddress, TransportError (..))
 import Network.Transport.QUIC.Internal.Configuration (Credential, mkClientConfig)
-import Network.Transport.QUIC.Internal.Messaging (MessageReceived (..), handshake, receiveMessage)
+import Network.Transport.QUIC.Internal.Messaging (ClientConnId, MessageReceived (..), handshake, receiveMessage)
 import Network.Transport.QUIC.Internal.QUICAddr (QUICAddr (QUICAddr), decodeQUICAddr)
 
 streamToEndpoint ::
@@ -28,6 +28,8 @@ streamToEndpoint ::
   EndPointAddress ->
   -- | Their address
   EndPointAddress ->
+  -- | Client-allocated connection id to send as part of the handshake
+  ClientConnId ->
   -- | On exception
   (SomeException -> IO ()) ->
   -- | On a message to forcibly close the connection
@@ -40,7 +42,7 @@ streamToEndpoint ::
           QUIC.Stream
         )
     )
-streamToEndpoint creds validateCreds ourAddress theirAddress onExc onCloseForcibly =
+streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onExc onCloseForcibly =
   case decodeQUICAddr theirAddress of
     Left errmsg -> pure $ Left (TransportError ConnectNotFound errmsg)
     Right (QUICAddr hostname servicename _) -> do
@@ -54,7 +56,7 @@ streamToEndpoint creds validateCreds ourAddress theirAddress onExc onCloseForcib
             QUIC.waitEstablished conn
             restore $
               bracket (QUIC.stream conn) QUIC.closeStream $ \stream -> do
-                handshake (ourAddress, theirAddress) stream
+                handshake (ourAddress, theirAddress) clientConnId stream
                   >>= either
                     (\_ -> putMVar streamMVar (Left $ TransportError ConnectNotFound "handshake failed"))
                     (\_ -> putMVar streamMVar (Right stream))

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
@@ -17,7 +17,7 @@ import Network.QUIC qualified as QUIC
 import Network.QUIC.Client qualified as QUIC.Client
 import Network.Transport (ConnectErrorCode (ConnectNotFound), EndPointAddress, TransportError (..))
 import Network.Transport.QUIC.Internal.Configuration (Credential, mkClientConfig)
-import Network.Transport.QUIC.Internal.Messaging (ClientConnId, MessageReceived (..), handshake, receiveMessage)
+import Network.Transport.QUIC.Internal.Messaging (MessageReceived (..), handshake, receiveMessage)
 import Network.Transport.QUIC.Internal.QUICAddr (QUICAddr (QUICAddr), decodeQUICAddr)
 
 streamToEndpoint ::
@@ -28,8 +28,6 @@ streamToEndpoint ::
   EndPointAddress ->
   -- | Their address
   EndPointAddress ->
-  -- | Client-allocated connection id to send as part of the handshake
-  ClientConnId ->
   -- | Called when the QUIC connection or stream ends without us having initiated the
   -- close. Must be idempotent (the caller typically gates on remote endpoint state so
   -- that repeated invocations are safe) — this handler is invoked from multiple sites
@@ -44,7 +42,7 @@ streamToEndpoint ::
           QUIC.Stream
         )
     )
-streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onConnLoss =
+streamToEndpoint creds validateCreds ourAddress theirAddress onConnLoss =
   case decodeQUICAddr theirAddress of
     Left errmsg -> pure $ Left (TransportError ConnectNotFound errmsg)
     Right (QUICAddr hostname servicename _) -> do
@@ -58,7 +56,7 @@ streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onConn
             QUIC.waitEstablished conn
             restore $
               bracket (QUIC.stream conn) QUIC.closeStream $ \stream -> do
-                handshake (ourAddress, theirAddress) clientConnId stream
+                handshake (ourAddress, theirAddress) stream
                   >>= either
                     (\_ -> putMVar streamMVar (Left $ TransportError ConnectNotFound "handshake failed"))
                     (\_ -> putMVar streamMVar (Right stream))
@@ -104,7 +102,7 @@ streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onConn
         Right StreamClosed -> mask_ $ do
           _ <- tryPutMVar doneMVar ()
           onConnLoss
-        Right (CloseConnection _) ->
+        Right CloseConnection ->
           -- Peer closed the logical connection cleanly; no ErrorEvent.
           () <$ tryPutMVar doneMVar ()
         Right CloseEndPoint -> mask_ $ do

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Client.hs
@@ -10,8 +10,8 @@ where
 
 import Control.Concurrent (forkIOWithUnmask, newEmptyMVar)
 import Control.Concurrent.Async (withAsync)
-import Control.Concurrent.MVar (MVar, putMVar, takeMVar)
-import Control.Exception (SomeException, bracket, catch, mask, mask_, throwIO)
+import Control.Concurrent.MVar (MVar, putMVar, takeMVar, tryPutMVar)
+import Control.Exception (SomeException, bracket, catch, finally, mask, mask_, throwIO)
 import Data.List.NonEmpty (NonEmpty)
 import Network.QUIC qualified as QUIC
 import Network.QUIC.Client qualified as QUIC.Client
@@ -30,9 +30,11 @@ streamToEndpoint ::
   EndPointAddress ->
   -- | Client-allocated connection id to send as part of the handshake
   ClientConnId ->
-  -- | On exception
-  (SomeException -> IO ()) ->
-  -- | On a message to forcibly close the connection
+  -- | Called when the QUIC connection or stream ends without us having initiated the
+  -- close. Must be idempotent (the caller typically gates on remote endpoint state so
+  -- that repeated invocations are safe) — this handler is invoked from multiple sites
+  -- (peer-initiated close signal, QUIC.Client.run exception, thread finally) to cover
+  -- every termination path.
   IO () ->
   IO
     ( Either
@@ -42,7 +44,7 @@ streamToEndpoint ::
           QUIC.Stream
         )
     )
-streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onExc onCloseForcibly =
+streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onConnLoss =
   case decodeQUICAddr theirAddress of
     Left errmsg -> pure $ Left (TransportError ConnectNotFound errmsg)
     Right (QUICAddr hostname servicename _) -> do
@@ -77,7 +79,8 @@ streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onExc 
                           (throwIO @SomeException)
                     )
               )
-              onExc
+              (\(_ :: SomeException) -> pure ())
+              `finally` onConnLoss
 
       streamOrError <- takeMVar streamMVar
 
@@ -87,11 +90,24 @@ streamToEndpoint creds validateCreds ourAddress theirAddress clientConnId onExc 
   listenForClose stream doneMVar =
     receiveMessage stream
       >>= \case
-        Right StreamClosed -> do
-          putMVar doneMVar ()
-        Right (CloseConnection _) -> do
-          putMVar doneMVar ()
-        Right CloseEndPoint -> do
-          putMVar doneMVar ()
-          onCloseForcibly
+        -- Any message from the peer on this stream means we're done listening.
+        -- Peer-initiated closes (StreamClosed/CloseEndPoint) additionally call
+        -- onConnLoss; the idempotent gate in the handler dedupes with the finally
+        -- that also fires on QUIC.Client.run exit.
+        --
+        -- Mask signalling+onConnLoss as an atomic pair: tryPutMVar unblocks
+        -- runClient's takeMVar, which causes withAsync to cancel this thread.
+        -- Without mask, the async ThreadKilled can fire partway through
+        -- onConnLoss, dropping the ErrorEvent. The finally in the parent thread
+        -- is a backup but cannot recover if surfaceConnectionLost already
+        -- transitioned the remote state to Closed.
+        Right StreamClosed -> mask_ $ do
+          _ <- tryPutMVar doneMVar ()
+          onConnLoss
+        Right (CloseConnection _) ->
+          -- Peer closed the logical connection cleanly; no ErrorEvent.
+          () <$ tryPutMVar doneMVar ()
+        Right CloseEndPoint -> mask_ $ do
+          _ <- tryPutMVar doneMVar ()
+          onConnLoss
         other -> throwIO . userError $ "Unexpected incoming message to client: " <> show other

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Network.Transport.QUIC.Internal.Messaging
   ( -- * Connections
@@ -236,19 +237,26 @@ sendCloseEndPoint stream =
     )
 
 -- | Handshake protocol that a client, connecting to a remote endpoint,
--- has to perform.
--- TODO: encode server part of the handhake
+-- has to perform. Two round-trips:
+--
+-- 1. client -> server: address payload
+-- 2. server -> client: ack1 (handshake payload accepted)
+-- 3. client -> server: clientConnId
+-- 4. server -> client: ack2 (ConnectionOpened has been enqueued on server's endpoint)
+--
+-- The ack2 step is load-bearing: when this function returns, the server has
+-- already written ConnectionOpened to its local queue. Without it, the server's
+-- @connect@ would return before the peer's queue has the ConnectionOpened event,
+-- which races with subsequent sends on other connections.
 handshake ::
   (EndPointAddress, EndPointAddress) ->
+  ClientConnId ->
   Stream ->
   IO (Either () ())
-handshake (ourAddress, theirAddress) stream =
+handshake (ourAddress, theirAddress) clientConnId stream =
   case decodeQUICAddr theirAddress of
     Left errmsg -> throwIO $ userError ("Could not decode QUIC address: " <> errmsg)
     Right (QUICAddr _ _ serverEndPointId) -> do
-      -- Handshake on connection creation, which simply involves
-      -- sending our address over, and
-      -- the endpoint ID of the endpoint we want to communicate with
       let encodedPayload = BS.toStrict $ Binary.encode (ourAddress, serverEndPointId)
           payloadLength = encodeWord32 $ fromIntegral (BS.length encodedPayload)
 
@@ -260,10 +268,14 @@ handshake (ourAddress, theirAddress) stream =
         >>= \case
           Left (_exc :: SomeException) -> pure $ Left ()
           Right _ ->
-            -- Server acknowledgement that the handshake is complete
-            -- means that we cannot send messages until the server
-            -- is ready for them
-            recvAck stream
+            recvAck stream >>= \case
+              Left () -> pure $ Left ()
+              Right () ->
+                try @SomeException
+                  (QUIC.sendStream stream (BS.toStrict (Binary.encode clientConnId)))
+                  >>= \case
+                    Left _ -> pure $ Left ()
+                    Right () -> recvAck stream
 
 -- | Part of the connection ID that is client-allocated.
 newtype ClientConnId = ClientConnId Word32

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
@@ -127,20 +127,23 @@ decodeMessage get =
     getWord32 = get 4 <&> decodeWord32
 
 -- | Wrap a method to fetch bytes, to ensure that we always get exactly the
--- intended number of bytes.
+-- intended number of bytes. Returns early (with the accumulated bytes) if the
+-- underlying fetcher signals EOF by returning an empty ByteString; otherwise a
+-- fetcher that repeatedly returns empty after a peer FIN would cause this to
+-- spin forever.
 getAllBytes ::
   -- | Function to fetch at most 'n' bytes
   (Int -> IO ByteString) ->
-  -- | Function to fetch exactly 'n' bytes
+  -- | Function to fetch exactly 'n' bytes (or fewer on EOF)
   (Int -> IO ByteString)
 getAllBytes get n = go n mempty
   where
     go 0 !acc = pure $ BS.concat acc
     go m !acc =
       get m >>= \bytes ->
-        go
-          (m - BS.length bytes)
-          (acc <> [bytes])
+        if BS.null bytes
+          then pure $ BS.concat acc
+          else go (m - BS.length bytes) (acc <> [bytes])
 
 data MessageReceived
   = Message

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/Messaging.hs
@@ -50,20 +50,19 @@ import Network.Transport (ConnectionId, EndPointAddress)
 import Network.Transport.Internal (decodeWord32, encodeWord32)
 import Network.Transport.QUIC.Internal.QUICAddr (QUICAddr (QUICAddr), decodeQUICAddr)
 
--- | Send a message to a remote endpoint ID
+-- | Send a message on the stream.
 --
 -- This function is thread-safe; while the data is sending, asynchronous
 -- exceptions are masked, to be rethrown after the data is sent.
 sendMessage ::
   Stream ->
-  ClientConnId ->
   [ByteString] ->
   IO (Either QUIC.QUICException ())
-sendMessage stream connId messages =
+sendMessage stream messages =
   try
     ( QUIC.sendStreamMany
         stream
-        (encodeMessage connId messages)
+        (encodeMessage messages)
     )
 
 -- | Receive a message, including its local destination endpoint ID
@@ -87,18 +86,15 @@ receiveMessage stream = mask $ \restore ->
 -- The encoding is composed of a header, and the payloads.
 -- The message header is composed of:
 -- 1. A control byte, to determine how the message should be parsed.
--- 2. A 32-bit word that encodes the endpoint ID of the destination endpoint;
--- 3. A 32-bit word that encodes the number of frames in the message
+-- 2. A 32-bit word that encodes the number of frames in the message
 --
 -- The payload frames are each prepended with the length of the frame.
 encodeMessage ::
-  ClientConnId ->
   [ByteString] ->
   [ByteString]
-encodeMessage connId messages =
+encodeMessage messages =
   BS.concat
     [ BS.singleton messageControlByte,
-      encodeWord32 (fromIntegral connId),
       encodeWord32 (fromIntegral $ length messages)
     ]
     : [encodeWord32 (fromIntegral $ BS.length message) <> message | message <- messages]
@@ -116,13 +112,12 @@ decodeMessage get =
   where
     go ctrl
       | ctrl == closeEndPointControlByte = pure $ Right CloseEndPoint
-      | ctrl == closeConnectionControlByte = Right . CloseConnection . fromIntegral <$> getWord32
+      | ctrl == closeConnectionControlByte = pure $ Right CloseConnection
       | ctrl == messageControlByte = do
-          connId <- getWord32
           numMessages <- getWord32
           messages <- replicateM (fromIntegral numMessages) $ do
             getWord32 >>= get . fromIntegral
-          pure . Right $ Message (fromIntegral connId) messages
+          pure . Right $ Message messages
       | otherwise = pure $ Left $ "Unsupported control byte: " <> show ctrl
     getWord32 = get 4 <&> decodeWord32
 
@@ -146,10 +141,8 @@ getAllBytes get n = go n mempty
           else go (m - BS.length bytes) (acc <> [bytes])
 
 data MessageReceived
-  = Message
-      {-# UNPACK #-} !ClientConnId
-      {-# UNPACK #-} ![ByteString]
-  | CloseConnection !ClientConnId
+  = Message {-# UNPACK #-} ![ByteString]
+  | CloseConnection
   | CloseEndPoint
   | StreamClosed
   deriving (Show, Eq)
@@ -220,13 +213,12 @@ closeConnectionControlByte :: ControlByte
 closeConnectionControlByte = 255
 
 -- | Send a message to close the connection.
-sendCloseConnection :: ClientConnId -> Stream -> IO (Either QUIC.QUICException ())
-sendCloseConnection connId stream =
+sendCloseConnection :: Stream -> IO (Either QUIC.QUICException ())
+sendCloseConnection stream =
   try
     ( QUIC.sendStream
         stream
-        ( BS.concat [BS.singleton closeConnectionControlByte, encodeWord32 (fromIntegral connId)]
-        )
+        (BS.singleton closeConnectionControlByte)
     )
 
 -- | Send a message to close the connection.
@@ -240,12 +232,11 @@ sendCloseEndPoint stream =
     )
 
 -- | Handshake protocol that a client, connecting to a remote endpoint,
--- has to perform. Two round-trips:
+-- has to perform:
 --
 -- 1. client -> server: address payload
 -- 2. server -> client: ack1 (handshake payload accepted)
--- 3. client -> server: clientConnId
--- 4. server -> client: ack2 (ConnectionOpened has been enqueued on server's endpoint)
+-- 3. server -> client: ack2 (ConnectionOpened has been enqueued on server's endpoint)
 --
 -- The ack2 step is load-bearing: when this function returns, the server has
 -- already written ConnectionOpened to its local queue. Without it, the server's
@@ -253,10 +244,9 @@ sendCloseEndPoint stream =
 -- which races with subsequent sends on other connections.
 handshake ::
   (EndPointAddress, EndPointAddress) ->
-  ClientConnId ->
   Stream ->
   IO (Either () ())
-handshake (ourAddress, theirAddress) clientConnId stream =
+handshake (ourAddress, theirAddress) stream =
   case decodeQUICAddr theirAddress of
     Left errmsg -> throwIO $ userError ("Could not decode QUIC address: " <> errmsg)
     Right (QUICAddr _ _ serverEndPointId) -> do
@@ -273,12 +263,7 @@ handshake (ourAddress, theirAddress) clientConnId stream =
           Right _ ->
             recvAck stream >>= \case
               Left () -> pure $ Left ()
-              Right () ->
-                try @SomeException
-                  (QUIC.sendStream stream (BS.toStrict (Binary.encode clientConnId)))
-                  >>= \case
-                    Left _ -> pure $ Left ()
-                    Right () -> recvAck stream
+              Right () -> recvAck stream
 
 -- | Part of the connection ID that is client-allocated.
 newtype ClientConnId = ClientConnId Word32

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
@@ -72,11 +72,9 @@ where
 import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, putMVar, readMVar)
 import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
-import Control.Exception (Exception (displayException), SomeException, bracketOnError, try)
+import Control.Exception (bracketOnError)
 import Control.Monad (forM_)
 import Control.Monad.STM (atomically)
-import Data.Binary qualified as Binary
-import Data.ByteString qualified as BS
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
@@ -85,7 +83,6 @@ import Data.Map.Strict qualified as Map
 import Data.Word (Word32)
 import Lens.Micro.Platform (makeLenses, (%~), (+~), (^.))
 import Network.QUIC (Stream)
-import Network.QUIC qualified as QUIC
 import Network.Socket (HostName, ServiceName, Socket)
 import Network.Socket qualified as N
 import Network.TLS (Credential)
@@ -406,19 +403,24 @@ createConnectionTo ::
 createConnectionTo creds validateCreds localEndPoint remoteAddress = do
   createRemoteEndPoint localEndPoint remoteAddress Outgoing >>= \case
     Left err -> pure $ Left err
-    Right (remoteEndPoint, _) ->
+    Right (remoteEndPoint, _) -> do
+      -- TODO: each call to @connect@ currently opens a dedicated QUIC connection and
+      -- its logical connection id is always 0. To multiplex multiple logical
+      -- connections on a single stream (the purpose of @_remoteNextConnOutId@), this
+      -- should draw from and advance that counter instead of being hardcoded.
+      let clientConnId = 0
       streamToEndpoint
         creds
         validateCreds
         (localEndPoint ^. localAddress)
         remoteAddress
+        clientConnId
         (onException remoteEndPoint)
         onConnectionLost
         >>= \case
           Left exc -> pure $ Left exc
           Right (closeStream, stream) -> do
-            let clientConnId = 0
-                validState =
+            let validState =
                   RemoteEndPointValid $
                     ValidRemoteEndPointState
                       { _remoteStream = stream,
@@ -429,17 +431,7 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
             modifyMVar_
               (remoteEndPoint ^. remoteEndPointState)
               (\_ -> pure validState)
-
-            try
-              ( QUIC.sendStream
-                  stream
-                  ( BS.toStrict $
-                      Binary.encode clientConnId
-                  )
-              )
-              >>= \case
-                Left (exc :: SomeException) -> pure . Left $ TransportError ConnectFailed (displayException exc)
-                Right () -> pure $ Right (remoteEndPoint, clientConnId)
+            pure $ Right (remoteEndPoint, clientConnId)
   where
     onException remoteEndPoint _exception = do
         -- The handler runs when QUIC.Client.run exits with an exception — i.e. the

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
@@ -60,8 +60,6 @@ module Network.Transport.QUIC.Internal.QUICTransport
     ValidRemoteEndPointState (..),
     remoteStream,
     remoteStreamIsClosed,
-    remoteIncoming,
-    remoteNextConnOutId,
     Direction (..),
 
     -- * Re-exports
@@ -228,9 +226,7 @@ data RemoteEndPointState
 
 data ValidRemoteEndPointState = ValidRemoteEndPointState
   { _remoteStream :: Stream,
-    _remoteStreamIsClosed :: MVar (),
-    _remoteIncoming :: !(Maybe ClientConnId),
-    _remoteNextConnOutId :: !ClientConnId
+    _remoteStreamIsClosed :: MVar ()
   }
 
 makeLenses ''QUICTransport
@@ -345,10 +341,10 @@ closeRemoteEndPoint direction remoteEndPoint = do
   mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
     RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
     RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
-    RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
+    RemoteEndPointValid (ValidRemoteEndPointState stream isClosed) ->
       let cleanup = do
             _ <- case direction of
-              Outgoing -> Right <$> forM_ conns (`sendCloseConnection` stream)
+              Outgoing -> sendCloseConnection stream
               Incoming -> sendCloseEndPoint stream
             _ <- tryPutMVar isClosed ()
             pure ()
@@ -401,18 +397,21 @@ createConnectionTo ::
   Bool ->
   LocalEndPoint ->
   EndPointAddress ->
-  IO (Either (TransportError ConnectErrorCode) (RemoteEndPoint, ClientConnId))
+  IO (Either (TransportError ConnectErrorCode) RemoteEndPoint)
 createConnectionTo creds validateCreds localEndPoint remoteAddress = do
   createRemoteEndPoint localEndPoint remoteAddress Outgoing >>= \case
     Left err -> pure $ Left err
     Right (remoteEndPoint, _) -> do
-      let clientConnId = 0
+      -- TODO: each call to @connect@ currently opens a dedicated QUIC connection
+      -- and carries a single logical connection on its stream. Preferred
+      -- architecture: one QUIC connection per (local endpoint, peer endpoint)
+      -- pair, with each logical connection carried on its own stream. Streams
+      -- already give us independent flow control and avoid head-of-line blocking.
       streamToEndpoint
         creds
         validateCreds
         (localEndPoint ^. localAddress)
         remoteAddress
-        clientConnId
         (surfaceConnectionLost remoteEndPoint)
         >>= \case
           Left exc -> pure $ Left exc
@@ -421,14 +420,12 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
                   RemoteEndPointValid $
                     ValidRemoteEndPointState
                       { _remoteStream = stream,
-                        _remoteStreamIsClosed = closeStream,
-                        _remoteIncoming = Nothing,
-                        _remoteNextConnOutId = clientConnId + 1
+                        _remoteStreamIsClosed = closeStream
                       }
             modifyMVar_
               (remoteEndPoint ^. remoteEndPointState)
               (\_ -> pure validState)
-            pure $ Right (remoteEndPoint, clientConnId)
+            pure $ Right remoteEndPoint
   where
     -- Idempotent: surfaces EventConnectionLost exactly once, only if the remote
     -- endpoint was still Valid when invoked. Called from multiple termination
@@ -438,9 +435,9 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
       mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
         RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
         RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
-        RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
+        RemoteEndPointValid (ValidRemoteEndPointState stream isClosed) ->
           let cleanup = do
-                forM_ conns $ \c -> sendCloseConnection c stream
+                _ <- sendCloseConnection stream
                 _ <- tryPutMVar isClosed ()
                 onConnectionLost
            in pure (RemoteEndPointClosed, Just cleanup)

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
@@ -70,7 +70,7 @@ module Network.Transport.QUIC.Internal.QUICTransport
 where
 
 import Control.Concurrent.Async (forConcurrently_)
-import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, putMVar, readMVar)
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, readMVar, tryPutMVar)
 import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
 import Control.Exception (bracketOnError)
 import Control.Monad (forM_)
@@ -326,8 +326,9 @@ closeLocalEndpoint quicTransport localEndPoint = do
           pure
             ( RemoteEndPointClosed,
               Just $ do
-                sendCloseEndPoint (vst ^. remoteStream)
-                  >> putMVar (vst ^. remoteStreamIsClosed) ()
+                _ <- sendCloseEndPoint (vst ^. remoteStream)
+                _ <- tryPutMVar (vst ^. remoteStreamIsClosed) ()
+                pure ()
             )
 
       case mCleanup of
@@ -345,11 +346,12 @@ closeRemoteEndPoint direction remoteEndPoint = do
     RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
     RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
     RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
-      let cleanup =
-            case direction of
+      let cleanup = do
+            _ <- case direction of
               Outgoing -> Right <$> forM_ conns (`sendCloseConnection` stream)
               Incoming -> sendCloseEndPoint stream
-              >> putMVar isClosed ()
+            _ <- tryPutMVar isClosed ()
+            pure ()
        in pure (RemoteEndPointClosed, Just cleanup)
 
   case mAct of
@@ -404,10 +406,6 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
   createRemoteEndPoint localEndPoint remoteAddress Outgoing >>= \case
     Left err -> pure $ Left err
     Right (remoteEndPoint, _) -> do
-      -- TODO: each call to @connect@ currently opens a dedicated QUIC connection and
-      -- its logical connection id is always 0. To multiplex multiple logical
-      -- connections on a single stream (the purpose of @_remoteNextConnOutId@), this
-      -- should draw from and advance that counter instead of being hardcoded.
       let clientConnId = 0
       streamToEndpoint
         creds
@@ -415,8 +413,7 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
         (localEndPoint ^. localAddress)
         remoteAddress
         clientConnId
-        (onException remoteEndPoint)
-        onConnectionLost
+        (surfaceConnectionLost remoteEndPoint)
         >>= \case
           Left exc -> pure $ Left exc
           Right (closeStream, stream) -> do
@@ -433,25 +430,23 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
               (\_ -> pure validState)
             pure $ Right (remoteEndPoint, clientConnId)
   where
-    onException remoteEndPoint _exception = do
-        -- The handler runs when QUIC.Client.run exits with an exception — i.e. the
-        -- peer tore down the connection before we did. If the remote endpoint was
-        -- still Valid when this fires, our side had not initiated the close, so we
-        -- surface an EventConnectionLost. (If state is already Closed, we initiated
-        -- the close ourselves and the QUIC exception is just teardown noise.)
-        do
-            mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
-              RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
-              RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
-              RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
-                let cleanup = do
-                      forM_ conns $ \c -> sendCloseConnection c stream
-                      putMVar isClosed ()
-                      onConnectionLost
-                 in pure (RemoteEndPointClosed, Just cleanup)
-            case mAct of
-              Nothing -> pure ()
-              Just act -> act
+    -- Idempotent: surfaces EventConnectionLost exactly once, only if the remote
+    -- endpoint was still Valid when invoked. Called from multiple termination
+    -- sites (peer-initiated close, QUIC exception, forked-thread finally) so that
+    -- no close path can leave us silent — the state-transition gate dedupes them.
+    surfaceConnectionLost remoteEndPoint = do
+      mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
+        RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
+        RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
+        RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
+          let cleanup = do
+                forM_ conns $ \c -> sendCloseConnection c stream
+                _ <- tryPutMVar isClosed ()
+                onConnectionLost
+           in pure (RemoteEndPointClosed, Just cleanup)
+      case mAct of
+        Nothing -> pure ()
+        Just act -> act
     onConnectionLost =
       atomically
         . writeTQueue (localEndPoint ^. localQueue)

--- a/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
+++ b/packages/network-transport-quic/src/Network/Transport/QUIC/Internal/QUICTransport.hs
@@ -311,10 +311,13 @@ closeLocalEndpoint quicTransport localEndPoint = do
     LocalEndPointStateClosed -> pure (LocalEndPointStateClosed, Nothing)
     LocalEndPointStateValid st -> pure (LocalEndPointStateClosed, Just st)
 
-  forM_ mPreviousState $ \vst ->
-    forConcurrently_
-      (vst ^. incomingConnections <> vst ^. outgoingConnections)
-      tryCloseRemoteStream
+  -- Close outgoing remote endpoints before incoming. The peer's handleIncomingMessages
+  -- reader writes ConnectionClosed in response to our outgoing close; its listenForClose
+  -- writes ErrorEvent in response to our incoming close. Processing outgoing first gives
+  -- the peer's event queue the expected ConnectionClosed-before-ErrorEvent ordering.
+  forM_ mPreviousState $ \vst -> do
+    forConcurrently_ (vst ^. outgoingConnections) tryCloseRemoteStream
+    forConcurrently_ (vst ^. incomingConnections) tryCloseRemoteStream
   atomically $ writeTQueue (localEndPoint ^. localQueue) EndPointClosed
   where
     tryCloseRemoteStream :: RemoteEndPoint -> IO ()
@@ -409,7 +412,7 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
         validateCreds
         (localEndPoint ^. localAddress)
         remoteAddress
-        (\_ -> closeRemoteEndPoint Outgoing remoteEndPoint)
+        (onException remoteEndPoint)
         onConnectionLost
         >>= \case
           Left exc -> pure $ Left exc
@@ -438,6 +441,25 @@ createConnectionTo creds validateCreds localEndPoint remoteAddress = do
                 Left (exc :: SomeException) -> pure . Left $ TransportError ConnectFailed (displayException exc)
                 Right () -> pure $ Right (remoteEndPoint, clientConnId)
   where
+    onException remoteEndPoint _exception = do
+        -- The handler runs when QUIC.Client.run exits with an exception — i.e. the
+        -- peer tore down the connection before we did. If the remote endpoint was
+        -- still Valid when this fires, our side had not initiated the close, so we
+        -- surface an EventConnectionLost. (If state is already Closed, we initiated
+        -- the close ourselves and the QUIC exception is just teardown noise.)
+        do
+            mAct <- modifyMVar (remoteEndPoint ^. remoteEndPointState) $ \case
+              RemoteEndPointInit -> pure (RemoteEndPointClosed, Nothing)
+              RemoteEndPointClosed -> pure (RemoteEndPointClosed, Nothing)
+              RemoteEndPointValid (ValidRemoteEndPointState stream isClosed conns _) ->
+                let cleanup = do
+                      forM_ conns $ \c -> sendCloseConnection c stream
+                      putMVar isClosed ()
+                      onConnectionLost
+                 in pure (RemoteEndPointClosed, Just cleanup)
+            case mAct of
+              Nothing -> pure ()
+              Just act -> act
     onConnectionLost =
       atomically
         . writeTQueue (localEndPoint ^. localQueue)

--- a/packages/network-transport-quic/test/Test/Network/Transport/QUIC/Internal/Messaging.hs
+++ b/packages/network-transport-quic/test/Test/Network/Transport/QUIC/Internal/Messaging.hs
@@ -21,20 +21,16 @@ tests =
 
 testMessageEncodingAndDecoding :: TestTree
 testMessageEncodingAndDecoding = testProperty "Encoded messages can be decoded" $ property $ do
-    -- The connection ID and message length are encoded and decoded the same way, to/from
-    -- a Word32.
-    -- To exercise the parsing of Word32s, we need to make sure that the range
-    -- of data is generated above a Word8 (255), including the connection ID
-    -- and the number of bytes in the message
-    endpointId <- fmap fromIntegral <$> forAll $ Gen.word32 Range.constantBounded
-
+    -- The message length is encoded and decoded as a Word32. Generate data above
+    -- a Word8 (255) to exercise the Word32 parsing of the number of bytes in each
+    -- message.
     messages <- forAll (Gen.list (Range.linear 0 3) (Gen.bytes (Range.linear 1 4096)))
-    let encoded = mconcat $ encodeMessage endpointId messages
+    let encoded = mconcat $ encodeMessage messages
 
     getBytes <- liftIO $ messageDecoder encoded
 
     decoded <- liftIO $ decodeMessage getBytes
-    Right (Message endpointId messages) === decoded
+    Right (Message messages) === decoded
 
 messageDecoder :: ByteString -> IO (Int -> IO ByteString)
 messageDecoder allBytes = do


### PR DESCRIPTION
This is a PR that aims to address at least some of the flakiness of the QUIC transport.

The most important change is the identification and removal of a race condition, in which a QUIC connection would accept messages before `ConnectionOpened` was fed to the application. This has been addressed.

There was also a removal of an explicit 500ms timeout during the initial QUIC handshake, instead relying on the upstream QUIC library to determine when a connection should be closed. 